### PR TITLE
Clangfix

### DIFF
--- a/common/algorithms/alignment/BaseScoreFunction.h
+++ b/common/algorithms/alignment/BaseScoreFunction.h
@@ -14,7 +14,7 @@ class BaseScoreFunction {
     affineOpen = affineExtend = 0;
   }
 
-  BaseScoreFunction(int insP, int delP, int subPriorP, int delPriorP, int affineExtensionP, int affineOpenP)  {
+  BaseScoreFunction(int insP, int delP, int subPriorP, int delPriorP, int affineExtensionP = 0 , int affineOpenP = 0)  {
     ins = insP;
     del = delP;
     substitutionPrior = subPriorP;

--- a/common/data/hdf/BufferedHDFArray.h
+++ b/common/data/hdf/BufferedHDFArray.h
@@ -71,7 +71,7 @@ class BufferedHDFArray : public HDFData, public HDFWriteBuffer<T> {
 			delete[] dimSize;
       dimSize = NULL;
 		}
-		this->HDFWriteBuffer<T>::~HDFWriteBuffer();
+		this->HDFWriteBuffer<T>::~HDFWriteBuffer<T>();
 	}
   
   void SetBufferSize(int _bufferSize) {

--- a/common/datastructures/reads/RegionTable.h
+++ b/common/datastructures/reads/RegionTable.h
@@ -7,6 +7,13 @@
 #include "../../Enumerations.h"
 using namespace std;
 
+/*
+  It appears that this class is being passed to something in the STL and that it is being compared to an int.
+  That comparison fails b/c there is no explicit cast-to-int for a RegionAnnotation.
+  
+  It looks like either you intend for some member function's return value to be passed to the STL algorithm,
+  or you want to write RegionAnnotation::int()const {} to allow the implicit cast to work
+ */
 class RegionAnnotation {
  public:
 	typedef enum T_AnnotationRow {HoleNumber, RegionType, RegionStart, RegionEnd, RegionScore} AnnotationRow;

--- a/common/ipc/SharedMemoryAllocator.h
+++ b/common/ipc/SharedMemoryAllocator.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <errno.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <sys/mman.h>
 
 using namespace std;


### PR DESCRIPTION
I have fixed all but one of the issues causing blasr to file to compile on clang.  

Please double-check the one that I have flagged that "PACbio needs to check".  You have a situation in the code where the number of arguments expected by a constructor and those passed to the constructor differ, and it is not clear what you intend.

The other two fixes are simple bug fixes.

I am working on the fourth one, but it is harder  to track down.