### PR TITLE
use vpath instead of VPATH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+defines.mk

--- a/configure.py
+++ b/configure.py
@@ -184,21 +184,21 @@ def parse_args(args):
             help='Can be different from source directory, but only when *not* also building submodule.')
     return parser.parse_args(list(args))
 
-def write_makefile(build_dir_root, src_dir_root, makefilename, relpath):
+def symlink_makefile(build_dir_root, src_dir_root, makefilename, relpath):
     src_dir = os.path.join(src_dir_root, relpath)
     build_dir = os.path.join(build_dir_root, relpath)
-    content = """\
-include %(src_dir)s/%(makefilename)s
-VPATH:=%(src_dir)s
-""" %dict(makefilename=makefilename, src_dir=src_dir)
+    src_name = os.path.join(src_dir, 'makefile')
+    dst_name = os.path.join(build_dir, 'makefile')
+    if os.path.lexists(dst_name):
+        os.unlink(dst_name)
+    print('%r <- %r' %(src_name, dst_name))
     mkdirs(build_dir)
-    fn = os.path.join(build_dir, makefilename)
-    update_content(fn, content)
+    os.symlink(src_name, dst_name)
 
-def write_makefiles(build_dir):
-    write_makefile(build_dir, ROOT, 'makefile', '.')
-    write_makefile(build_dir, ROOT, 'makefile', 'utils')
-    write_makefile(build_dir, ROOT, 'makefile', 'extrautils')
+def symlink_makefiles(build_dir):
+    symlink_makefile(build_dir, ROOT, 'makefile', '.')
+    symlink_makefile(build_dir, ROOT, 'makefile', 'utils')
+    symlink_makefile(build_dir, ROOT, 'makefile', 'extrautils')
 
 def main(prog, *args):
     """We are still deciding what env-vars to use, if any.
@@ -208,7 +208,7 @@ def main(prog, *args):
         os.environ['HDF5_INCLUDE'] = os.environ['HDF5_INC']
     conf, makevars = parse_args(args)
     if conf.build_dir is not None:
-        write_makefiles(conf.build_dir)
+        symlink_makefiles(conf.build_dir)
     else:
         conf.build_dir = '.'
     conf.build_dir = os.path.abspath(conf.build_dir)

--- a/configure.py
+++ b/configure.py
@@ -98,6 +98,7 @@ def compose_defines_pacbio(envin):
             'PBBAM_INCLUDE', 'PBBAM_LIB', 'PBBAM_LIBFLAGS',
             'HTSLIB_INCLUDE', 'HTSLIB_LIB', 'HTSLIB_LIBFLAGS',
             'BOOST_INCLUDE',
+            'GCC_LIB',
             'ZLIB_LIB', 'ZLIB_LIBFLAGS',
             'PTHREAD_LIBFLAGS',
             'DL_LIBFLAGS',

--- a/extrautils/makefile
+++ b/extrautils/makefile
@@ -1,9 +1,8 @@
 .PHONY=all cramtests
 
-THISDIR:=$(dir $(lastword $(MAKEFILE_LIST)))
-ROOT:=${THISDIR}/..
+SRCDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ${CURDIR}/../defines.mk
-include ${ROOT}/rules.mk
+include ${SRCDIR}/../rules.mk
 
 CXXOPTS := -std=c++0x -pedantic \
            -Wall -Wuninitialized -Wno-div-by-zero \
@@ -16,6 +15,7 @@ EXE = sa2bwt bwt2sa alchemy excrep evolve bsdb simpleShredder swMatcher \
 LD_LIBRARY_PATH=${HDF5_LIB}:${LIBBLASR_LIB}:${LIBPBIHDF_LIB}:${LIBPBDATA_LIB}
 export LD_LIBRARY_PATH
 
+vpath %.cpp ${SRCDIR}
 
 all: ${EXE}
 

--- a/makefile
+++ b/makefile
@@ -1,9 +1,13 @@
 all:
 
-THISDIR:=$(dir $(lastword $(MAKEFILE_LIST)))
-ROOT:=${THISDIR}
+SRCDIR:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 -include ${CURDIR}/defines.mk
-include ${THISDIR}/rules.mk
+-include ${SRCDIR}/rules.mk
+foo:
+	echo $(realpath $(firstword $(MAKEFILE_LIST)))
+	echo $(firstword $(MAKEFILE_LIST))
+	echo $(MAKEFILE_LIST)
+	echo ${SRCDIR}
 
 CXXFLAGS += -O3 -g
 CXXOPTS += \
@@ -28,6 +32,7 @@ DEPS := ${SRCS:.cpp=.d}
 LD_LIBRARY_PATH=${HDF5_LIB}:${LIBBLASR_LIB}:${LIBPBIHDF_LIB}:${LIBPBDATA_LIB}
 export LD_LIBRARY_PATH
 
+vpath %.cpp ${SRCDIR}
 
 init-submodule:
 	${MAKE} update-submodule

--- a/rules.mk
+++ b/rules.mk
@@ -13,6 +13,7 @@ LIBDIRS := \
 	${PBBAM_LIB} \
 	${HDF5_LIB} \
 	${HTSLIB_LIB} \
+	${GCC_LIB} \
 	${ZLIB_LIB}
 LDLIBS+= \
 	${LIBPBIHDF_LIBFLAGS} \

--- a/utils/makefile
+++ b/utils/makefile
@@ -1,9 +1,8 @@
 .PHONY=all cramtests
 
-THISDIR:=$(dir $(lastword $(MAKEFILE_LIST)))
-ROOT:=${THISDIR}/..
+SRCDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ${CURDIR}/../defines.mk
-include ${ROOT}/rules.mk
+include ${SRCDIR}/../rules.mk
 
 CXXOPTS := -std=c++0x -pedantic \
            -Wall -Wuninitialized -Wno-div-by-zero \
@@ -15,6 +14,7 @@ EXE = loadPulses pls2fasta samtoh5 samtom4 samFilter toAfg sawriter sdpMatcher
 LD_LIBRARY_PATH=${HDF5_LIB}:${LIBBLASR_LIB}:${LIBPBIHDF_LIB}:${LIBPBDATA_LIB}
 export LD_LIBRARY_PATH
 
+vpath %.cpp ${SRCDIR}
 
 all: ${EXE}
 


### PR DESCRIPTION
This fixes the problem of building in the source-tree and then building in an external directory.

Internally, see:
  http://bugzilla.nanofluidics.com/show_bug.cgi?id=27485