### PR TITLE
Remove 'using' from public header.

### DIFF
--- a/iblasr/RegisterFilterOptions.h
+++ b/iblasr/RegisterFilterOptions.h
@@ -1,13 +1,12 @@
 #include <libconfig.h>
 #include <CommandLineParser.hpp>
 #include <datastructures/alignment/FilterCriteria.hpp>
-#include <sstream>
-using namespace std;
+#include <string>
 
 /// Register options for filtering alignments.
 void RegisterFilterOptions(CommandLineParser & clp, int & minAlnLength,
                            float & minPctSimilarity, float & minPctAccuracy,
-                           string & hitPolicyStr, bool & useScoreCutoff,
+                           std::string & hitPolicyStr, bool & useScoreCutoff,
                            int & scoreSignInt, int & scoreCutoff) {
     ScoreSign ss = static_cast<ScoreSign>(scoreSignInt);
     Score sc(static_cast<float>(scoreCutoff),  ss);


### PR DESCRIPTION
Unlike the rest of `iblasr/*`, RegisterFilterOptions.h is included by a program in `utils/*`. That makes it pseudo public (though still not used outside this package), so it should not have a global using statement.

The non-public headers are in iblasr/ for the purpose of making the parent directory look cleaner. They could be moved safely.