### PR TITLE
CXXFLAGS for configure.py

### DIFF
--- a/README.INSTALL.md
+++ b/README.INSTALL.md
@@ -71,6 +71,16 @@ To build BLASR, you must have hdf 1.8.12 or above installed and
         make blasr
         ./blasr
 
+### CXXFLAGS
+
+* For optimized builds:
+
+    ./configure.py CXXFLAGS=-O3 ...
+
+* For debug builds:
+
+    ./configure.py CXXFLAGS=-g ...
+
 ## Other issues
 ### Static binaries
 If you want static binaries, drop `--shared` when you run configure.py. In that case, you

--- a/configure.py
+++ b/configure.py
@@ -78,7 +78,7 @@ def update_env_if(envout, envin, keys):
         if key in envin:
             envout[key] = envin[key]
 def compose_defs_env(env):
-    # We disallow env overrides for anything with a default from GNU make.
+    # We disallow env overrides for some things with defaults from GNU make.
     nons = ['CXX', 'CC', 'AR'] # 'SHELL'?
     ovr    = ['%-20s ?= %s' %(k, v) for k,v in env.items() if k not in nons]
     nonovr = ['%-20s := %s' %(k, v) for k,v in env.items() if k in nons]
@@ -93,7 +93,8 @@ def compose_defines_pacbio(envin):
     #setifenvf(env, envin, 'PREBUILT', get_PREBUILT)
     nondefaults = set([
             'CXX',
-            'BLASR_INC',
+            'CXXFLAGS',
+            'NO_PBBAM',
             'LIBPBDATA_INC', 'LIBPBDATA_LIB', 'LIBPBDATA_LIBFLAGS',
             'LIBPBIHDF_INC', 'LIBPBIHDF_LIB', 'LIBPBIHDF_LIBFLAGS',
             'LIBBLASR_INC', 'LIBBLASR_LIB', 'LIBBLASR_LIBFLAGS',
@@ -172,6 +173,8 @@ def set_defs_defaults(env, nopbbam, with_szlib):
     }
     if not nopbbam:
         defaults.update(pbbam_defaults)
+    else:
+        defaults['NO_PBBAM'] = 1
     szlib_defaults = {
         'SZLIB_LIBFLAGS': '-lsz',
         #'ZLIB_LIBFLAGS': '-lz', # probably needed, but provided elsewhere

--- a/makefile
+++ b/makefile
@@ -39,17 +39,19 @@ vpath %.cpp ${SRCDIR}
 
 init-submodule:
 	${MAKE} update-submodule
+        ${MAKE} configure-submodule
 	${MAKE} build-submodule
 
 update-submodule:
 	git submodule update --init
 
+configure-submodule:
+        ${MAKE} -f ${SRCDIR}/sub.mk configure-submodule
+
 build-submodule:
-	# DON'T use pbbam which is not on github.
-	cd libcpp && NOPBBAM=true HDF5_LIB=${HDF5_LIB} HDF5_INC=${HDF5_INC} ./configure.py
 	${MAKE} -C libcpp
 
-submodule-clean:
+clean-submodule
 	${RM} -r libcpp
 
 # The rules above must be run separately.


### PR DESCRIPTION
    ./configure.py CXXFLAGS=-g <plus other args...>

This should also handle --no-pbbam better, via NO_PBBAM in `defines.mk`.

* https://github.com/PacificBiosciences/blasr_libcpp/compare/b9e2095...ebc49d4

See PacificBiosciences/blasr_libcpp#78.