### PR TITLE
[issue #136] Removing override of nproc for osx.

### DIFF
--- a/MappingParameters.h
+++ b/MappingParameters.h
@@ -416,11 +416,6 @@ public:
             }
         }
 
-#ifdef __APPLE__
-        nProc = 1;
-        cerr << "WARNING, multi-threading is not yet supported on Apple iOS." << endl;
-#endif
-
         // -useQuality can not be used in combination with a fasta input
         if (!ignoreQualities) {
             if (queryFileType == Fasta) {


### PR DESCRIPTION
  In the past, we didnot have test coverage on the mac and earlier versions
of Mac OS X were not happy with blasr code as well. Now this becomes clang-
-buildable, and the multi-thread in BSD-land of osx seems to be better. As
to the test case, we should have multiple sequences in a query fasta. I am
considering adding my (working) test to the internal p4 or gh repository.