### PR TITLE
Support dataset

### DIFF
--- a/Blasr.cpp
+++ b/Blasr.cpp
@@ -298,7 +298,6 @@ void MapReadsNonCCS(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapDa
     bwtPtr = mapData->bwtPtr;
     SeqBoundaryFtr<FASTQSequence> seqBoundary(&seqdb);
 
-
     vector<ReadInterval> subreadIntervals;
     vector<int>          subreadDirections;
     int bestSubreadIndex;
@@ -1361,10 +1360,12 @@ int main(int argc, char* argv[]) {
     if (reader->GetFileType() != HDFCCS and 
         reader->GetFileType() != HDFBase and
         reader->GetFileType() != HDFPulse and
-        reader->GetFileType() != BAM and
+        reader->GetFileType() != PBBAM and
+        reader->GetFileType() != PBDATASET and
         params.concordant) {
         cerr << "WARNING! Option concordant is only enabled when "
-             << "input reads are in PacBio bax/pls.h5 or bam format." << endl;
+             << "input reads are in PacBio bax/pls.h5, bam or "
+             << "dataset xml format." << endl;
         params.concordant = false;
     }
 

--- a/ctest/dataset.t
+++ b/ctest/dataset.t
@@ -1,0 +1,40 @@
+Set up
+  $ . $TESTDIR/setup.sh
+
+Must copy all data to the current dir before bug 28912 is solved.
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.1.subreads.bam . 
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.1.subreads.bam.pbi . 
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.2.subreads.bam . 
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.2.subreads.bam.pbi . 
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.3.subreads.bam . 
+  $ cp $DATDIR/test_dataset/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.3.subreads.bam.pbi . 
+
+Test dataset.xml as input
+  $ $EXEC $DATDIR/test_dataset/chunking.subreadset.xml $DATDIR/ecoli_reference.fasta -m 4 -out $OUTDIR/chunking.m4 -bestn 1 && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+Test filters in dataset.xml is respected.
+  $ cat $OUTDIR/chunking.m4 | wc -l
+  9
+
+Test dataset.xml -bam output
+  $ $EXEC $DATDIR/test_dataset/chunking.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/chunking.bam  && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+
+Test dataset.xml -concordant
+  $ $EXEC $DATDIR/test_dataset/chunking.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/chunking.concordant.bam -concordant && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+
+Test dataset with no filters (to make sure that an empty filter does not discard all bam records.)
+  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/nofilter.bam -concordant -bestn 1 && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+
+  $ $SAMTOOLS view $OUTDIR/nofilter.bam|wc -l
+  135

--- a/iblasr/MappingParameters.h
+++ b/iblasr/MappingParameters.h
@@ -562,9 +562,9 @@ public:
                 // Only support two clipping methods: soft or subread.
                 clipping = SAMOutput::subread;
             }
-            if (queryFileType != PBBAM and not enableHiddenPaths) {
+            if (queryFileType != PBBAM and queryFileType != PBDATASET and not enableHiddenPaths) {
                 // bax|fasta|fastq -> bam paths are turned off by default
-                cout << "ERROR, could not output alignments in BAM unless input reads are in PacBio BAM files." << endl;
+                cout << "ERROR, could not output alignments in BAM unless input reads are in PacBio BAM or DATASET files." << endl;
                 exit(1);
             }
             if (outFileName == "") {


### PR DESCRIPTION
Enable -bam and -concordant when input files are datasets.xml
Added cram tests to test blasr taking dataset xml as input with/without -bam -concordant