### PR TITLE
Blasr: avoid non-full-pass subreads as concordant template.

### DIFF
--- a/Blasr.cpp
+++ b/Blasr.cpp
@@ -166,7 +166,7 @@ void MakePrimaryIntervals(vector<SMRTSequence> & subreads,
 {
     MakeSubreadIntervals(subreads, subreadIntervals);
     CreateDirections(subreadDirections, subreadIntervals.size());
-    bestSubreadIndex = GetIndexOfMedian(subreadIntervals);
+    bestSubreadIndex = GetIndexOfConcordantTemplate(subreadIntervals); 
 }
 
 
@@ -326,6 +326,11 @@ void MapReadsNonCCS(MappingData<T_SuffixArray, T_GenomeSequence, T_Tuple> *mapDa
         // Only the longest subread will be aligned in the first round.
         startIndex = max(startIndex, bestSubreadIndex);
         endIndex   = min(endIndex, bestSubreadIndex + 1);
+
+        if (params.verbosity >= 1) {
+            cout << "Concordant template subread index: " << bestSubreadIndex << ", " 
+                 << smrtRead.HoleNumber() << "/" << subreadIntervals[bestSubreadIndex] << endl;
+        }
     }
 
     //

--- a/ctest/bamConcordant.t
+++ b/ctest/bamConcordant.t
@@ -8,19 +8,26 @@ Test using bam as input, use -concordant
 
 Check whether sam out and bam out have identical alignments, not checking qvs
   $ $SAMTOOLS view $OUTDIR/bamConcordant.bam |cut -f 4 
-  8067
-  8051
-  730
-  690
-  690
-  690
-  691
-  690
-  690
-  693
-  690
-  690
-  690
-  697
-  695
-  690
+  1
+  1
+  8??? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+  86?? (glob)
+
+  $ $EXEC /pbi/dept/secondary/siv/testdata/SA3-RS/lambda/2372215/0007_tiny/Analysis_Results/m150404_101626_42267_c100807920800000001823174110291514_s1_p0.1.subreads.bam $DATDIR/lambda_ref.fasta -m 4 -concordant -bestn 1 -holeNumbers 17417 -out $OUTDIR/tmp.m4 -V 2 > $OUTDIR/bamConcordant.log
+  [INFO]* (glob)
+  [INFO]* (glob)
+
+  $ grep "Concordant template" $OUTDIR/bamConcordant.log
+  Concordant template subread index: 8, 17417/14708_16595

--- a/iblasr/BlasrMiscs.hpp
+++ b/iblasr/BlasrMiscs.hpp
@@ -53,8 +53,13 @@ void MakeVirtualRead(SMRTSequence & smrtRead,
 void MakeSubreadIntervals(vector<SMRTSequence> & subreads,
                           vector<ReadInterval> & subreadIntervals);
 
-// Get index of median length interval
-int GetIndexOfMedian(const vector<ReadInterval> & subreadIntervals);
+// Return index of subread which will be used as concordant template.
+// If Zmw has exactly one subread, return index of the subread (i.e., 0).
+// If Zmw has exactly two subreads, return index of the longer subread.
+// If Zmw has three or more subreads, return index of the median-length
+// subread in range subreadIntervals[1:-1]. Avoid using the first and last 
+// subreads (which are less likely to be full-pass) if possible.
+int GetIndexOfConcordantTemplate(const vector<ReadInterval> & subreadIntervals);
 
 //-------------------------MISC-----------------------------------//
 int CountZero(unsigned char *ptr, int length);


### PR DESCRIPTION
Blasr should use 'full-pass' subreads as concordant
template if possible. However this info is not available in
subreads.bam. Since we know that the first and last subreads
are less likely to be full-pass, here we changed blasr so that
it avoid using the first and last subreads as concordant
template when input is subreads.bam.

update cram tests for bam concordant.
update libcpp