### PR TITLE
Ajacent indels not allowed in SAM/BAM Cigar string by default

### DIFF
--- a/ctest/cigarAdjecentIndels.t
+++ b/ctest/cigarAdjecentIndels.t
@@ -1,0 +1,27 @@
+Set up
+  $ . $TESTDIR/setup.sh
+
+Without -allowAdjacentIndels, adjacent indels should not exist in SAM/BAM CIGAR strings
+  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/noAdjacentIndels.bam -concordant -bestn 1 && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+
+  $ $SAMTOOLS view $OUTDIR/noAdjacentIndels.bam |cut -f 6 |sed 's/[0-9]//g' > $TMP1 && echo $?
+  0
+
+  $ sed -n 's/ID/ID/g' $TMP1
+  $ sed -n 's/DI/DI/g' $TMP1
+
+With -allowAdjacentIndels, adjacent indels may exist in SAM/BAM CIGAR strings
+  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/allowAdjacentIndels.bam -concordant -bestn 1 -allowAdjacentIndels && echo $?
+  [INFO]* (glob)
+  [INFO]* (glob)
+  0
+
+  $ $SAMTOOLS view $OUTDIR/allowAdjacentIndels.bam |cut -f 6 |sed 's/[0-9]//g' > $TMP2 && echo $?
+  0
+
+  $ sed -n 's/ID/ID/g' $TMP1
+  $ sed -n 's/DI/DI/g' $TMP1
+

--- a/iblasr/BlasrAlignImpl.hpp
+++ b/iblasr/BlasrAlignImpl.hpp
@@ -393,13 +393,6 @@ void MapRead(T_Sequence &read, T_Sequence &readRC, T_RefSequence &genome,
         RemoveOverlappingAlignments(alignmentPtrs, params);
     }
 
-    if (params.forPicard) {
-        int a;
-        for (a = 0; a < alignmentPtrs.size(); a++ ) {
-            alignmentPtrs[a]->OrderGapsByType();
-        }
-    }
-
     //
     // Look to see if the number of anchors found for this read match
     // what is expected given the expected distribution of number of

--- a/iblasr/BlasrUtilsImpl.hpp
+++ b/iblasr/BlasrUtilsImpl.hpp
@@ -968,11 +968,11 @@ void PrintAlignment(T_AlignmentCandidate &alignment,
                           alignment.qAlignedSeqPos, alignment.tAlignedSeqPos);
     }
     else if (params.printFormat == SAM) {
-      SAMOutput::PrintAlignment(alignment, fullRead, outFile, alignmentContext, params.samQVList, params.clipping, params.cigarUseSeqMatch);
+      SAMOutput::PrintAlignment(alignment, fullRead, outFile, alignmentContext, params.samQVList, params.clipping, params.cigarUseSeqMatch, params.allowAdjacentIndels);
     }
     else if (params.printFormat == BAM) {
 #ifdef USE_PBBAM
-      BAMOutput::PrintAlignment(alignment, fullRead, subread, *bamWriterPtr, alignmentContext, params.samQVList, params.clipping, params.cigarUseSeqMatch);
+      BAMOutput::PrintAlignment(alignment, fullRead, subread, *bamWriterPtr, alignmentContext, params.samQVList, params.clipping, params.cigarUseSeqMatch, params.allowAdjacentIndels);
 #else
       REQUIRE_PBBAM_ERROR();
 #endif

--- a/iblasr/MappingParameters.h
+++ b/iblasr/MappingParameters.h
@@ -173,7 +173,7 @@ public:
     int   globalDeletionPrior;
     bool  outputByThread;
     int   recurseOver;
-    bool  forPicard;
+    bool  allowAdjacentIndels;
     bool  separateGaps;
     string scoreMatrixString;
     bool  printDotPlots;
@@ -346,7 +346,7 @@ public:
         globalDeletionPrior = 13;
         outputByThread = false;
         recurseOver = 10000;
-        forPicard = false;
+        allowAdjacentIndels = false;
         separateGaps = false;
         scoreMatrixString = "";
         printDotPlots = false;
@@ -526,7 +526,6 @@ public:
         }
         if (printSAM) {
             printFormat = SAM;
-            forPicard = true;
         }
         //
         // Parse the clipping.
@@ -554,7 +553,6 @@ public:
 #else
             cigarUseSeqMatch = true; // ALWAYS true for BAM
             printFormat = BAM;
-            forPicard = true;
             printSAM = false;
             samQVList.SetDefaultQV();
             printSAMQV = true;

--- a/iblasr/RegisterBlasrOptions.h
+++ b/iblasr/RegisterBlasrOptions.h
@@ -38,9 +38,8 @@ void RegisterBlasrOptions(CommandLineParser & clp, MappingParameters & params) {
     clp.RegisterFlagOption("printOnlyBest", &params.printOnlyBest, "");
     clp.RegisterFlagOption("outputByThread", &params.outputByThread, "");
     clp.RegisterFlagOption("rbao", &params.refineBetweenAnchorsOnly, "");
-    clp.RegisterFlagOption("allowAdjacentIndels", &params.forPicard, "");
     clp.RegisterFlagOption("onegap", &params.separateGaps, "");
-    clp.RegisterFlagOption("allowAdjacentIndels", &params.forPicard, "");
+    clp.RegisterFlagOption("allowAdjacentIndels", &params.allowAdjacentIndels, "", false);
     clp.RegisterFlagOption("placeRepeatsRandomly", &params.placeRandomly, "");
     clp.RegisterIntOption("randomSeed", &params.randomSeed, "", CommandLineParser::Integer);
     clp.RegisterFlagOption("extend", &params.extendAlignments, "");


### PR DESCRIPTION
The default behaviour of BLASR has been changed such that  no adjacent indels are allowed in SAM/BAM cigar strings unless -allowAdjacentIndels is ON.
Added a cram test.