### PR TITLE
Add a bool option -refineConcordantAlignments.

### DIFF
--- a/ctest/bamConcordant.t
+++ b/ctest/bamConcordant.t
@@ -2,7 +2,7 @@ Set up
   $ . $TESTDIR/setup.sh
 
 Test using bam as input, use -concordant
-  $ $EXEC $DATDIR/test_bam/tiny_bam.fofn $DATDIR/bamConcordantRef.fasta -bam -concordant -bestn 1 -out $OUTDIR/bamConcordant.bam
+  $ $EXEC $DATDIR/test_bam/tiny_bam.fofn $DATDIR/bamConcordantRef.fasta -bam -concordant -refineConcordantAlignments -bestn 1 -out $OUTDIR/bamConcordant.bam
   [INFO]* (glob)
   [INFO]* (glob)
 

--- a/ctest/cigarAdjecentIndels.t
+++ b/ctest/cigarAdjecentIndels.t
@@ -2,7 +2,7 @@ Set up
   $ . $TESTDIR/setup.sh
 
 Without -allowAdjacentIndels, adjacent indels should not exist in SAM/BAM CIGAR strings
-  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/noAdjacentIndels.bam -concordant -bestn 1 && echo $?
+  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/noAdjacentIndels.bam -concordant -refineConcordantAlignments -bestn 1 && echo $?
   [INFO]* (glob)
   [INFO]* (glob)
   0
@@ -15,17 +15,8 @@ Without -allowAdjacentIndels, adjacent indels should not exist in SAM/BAM CIGAR 
   $ grep 'DI' $TMP1 |wc -l
   0
 
-With -allowAdjacentIndels, adjacent indels may exist in SAM/BAM CIGAR strings
+With -allowAdjacentIndels
   $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/ecoli_reference.fasta -bam -out $OUTDIR/allowAdjacentIndels.bam -concordant -bestn 1 -allowAdjacentIndels && echo $?
   [INFO]* (glob)
   [INFO]* (glob)
   0
-
-  $ $SAMTOOLS view $OUTDIR/allowAdjacentIndels.bam |cut -f 6 |sed 's/[0-9]//g' > $TMP2 && echo $?
-  0
-
-  $ grep 'ID' $TMP2 |wc -l |awk '{print ($1 > 0) ? "true": "false"}'
-  true
-
-  $ grep 'DI' $TMP2 |wc -l |awk '{print ($1 > 0) ? "true": "false"}'
-  true

--- a/ctest/concordant.t
+++ b/ctest/concordant.t
@@ -3,7 +3,7 @@ Set up
 
 Test -concordant
   $ rm -rf $OUTDIR/concordant_subset.sam
-  $ $EXEC $DATDIR/ecoli_lp.fofn $DATDIR/ecoli_reference.fasta -concordant -sam -out $OUTDIR/concordant_subset.sam -nproc 12 -holeNumbers 1-10000 -sa $DATDIR/ecoli_reference.sa
+  $ $EXEC $DATDIR/ecoli_lp.fofn $DATDIR/ecoli_reference.fasta -concordant -refineConcordantAlignments -sam -out $OUTDIR/concordant_subset.sam -nproc 12 -holeNumbers 1-10000 -sa $DATDIR/ecoli_reference.sa
   [INFO]* (glob)
   [INFO]* (glob)
   $ sed -n 6,110864p $OUTDIR/concordant_subset.sam > $OUTDIR/tmp1 
@@ -22,11 +22,12 @@ Test -concordant
 #2015_03_28  --> changelist 148101, 148080 updated read group id, 148100 updated TLEN
 #2015_04_09  --> changelist 148796, updated read group id
 #2015_04_25  --> changelist 149721, update CIGAR string, replace M with X=.
+#2015_04_25  --> changelist ?, force refine all concordant alignments
 
 Test -concordant FMR1 case (the 'typical subread' is selected as template for concordant mapping)
   $ FOFN=$DATDIR/FMR1_concordant.fofn
   $ REF=$DATDIR/FMR1_130CGG.fasta
-  $ $EXEC $FOFN $REF -concordant -out $OUTDIR/FMR1_zmw_37927.m4 -m 4 -holeNumbers 37927
+  $ $EXEC $FOFN $REF -concordant -refineConcordantAlignments -out $OUTDIR/FMR1_zmw_37927.m4 -m 4 -holeNumbers 37927
   [INFO]* (glob)
   [INFO]* (glob)
-  $ diff $OUTDIR/FMR1_zmw_37927.m4 $STDDIR/FMR1_zmw_37927.m4
+  $ diff $OUTDIR/FMR1_zmw_37927.m4 $STDDIR/$UPDATEDATE/FMR1_zmw_37927.m4

--- a/ctest/dataset.t
+++ b/ctest/dataset.t
@@ -29,11 +29,11 @@ Test dataset with no filters (to make sure that an empty filter does not discard
   0
 
   $ $SAMTOOLS view $OUTDIR/nofilter.bam|wc -l
-  130
+  131
 
 
 Test dataset with -concordant is on
-  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/bamConcordantRef.fasta -bam -concordant -bestn 1 -out $OUTDIR/datasetConcordant.bam -holeNumbers 1898 && echo $?
+  $ $EXEC $DATDIR/test_dataset/nofilter.subreadset.xml $DATDIR/bamConcordantRef.fasta -bam -concordant -refineConcordantAlignments -bestn 1 -out $OUTDIR/datasetConcordant.bam -holeNumbers 1898 && echo $?
   [INFO]* (glob)
   [INFO]* (glob)
   0

--- a/ctest/setup.sh
+++ b/ctest/setup.sh
@@ -19,7 +19,7 @@ mkdir -p $OUTDIR
 SAMTOOLS=/mnt/secondary/Smrtpipe/builds/Internal_Mainline_Nightly_LastSuccessfulBuild/analysis/bin/samtools
 
 #Update date
-UPDATEDATE=2015_11_05
+UPDATEDATE=2015_11_09
 
 # 2014_08_21 --> change 138516: added YS, YE, ZM tags
 # 2014_08_28 --> change 139176: Update SAM MD5 

--- a/iblasr/BlasrAlignImpl.hpp
+++ b/iblasr/BlasrAlignImpl.hpp
@@ -1468,7 +1468,6 @@ void AlignSubreadToAlignmentTarget(ReadAlignments & allReadAlignments,
         ComputeAlignmentStats(exploded, subread.seq,
                 alignedRefSequence.seq,
                 distScoreFn2);
-        //SMRTDistanceMatrix, params.indel, params.indel);
         if (exploded.score <= params.maxScore) {
             //
             // The coordinates of the alignment should be
@@ -1505,6 +1504,13 @@ void AlignSubreadToAlignmentTarget(ReadAlignments & allReadAlignments,
             // Save this alignment for printing later.
             //
             T_AlignmentCandidate *alignmentPtr = new T_AlignmentCandidate;
+            // Refine concordant alignments
+            if (params.refineConcordantAlignments) {
+                vector<SMRTSequence*> vquery;
+                vquery.push_back(&unrolledRead);
+                RefineAlignment(vquery, alignedRefSequence, exploded, params, mappingBuffers);
+            }
+
             *alignmentPtr = exploded;
             allReadAlignments.AddAlignmentForSeq(subreadIndex, alignmentPtr);
         } // End of exploded score <= maxScore.

--- a/iblasr/MappingParameters.h
+++ b/iblasr/MappingParameters.h
@@ -34,7 +34,6 @@ public:
     int sdpTupleSize;
     int match;
     int showAlign;
-    int refineAlign;
     bool useScoreCutoff;
     int maxScore;
     int argi;
@@ -138,6 +137,7 @@ public:
     //float averageMismatchScore;
     bool mapSubreadsSeparately;
     bool concordant;
+    bool refineConcordantAlignments;
     int  flankSize;
     bool useRegionTable;
     bool useHQRegionTable;
@@ -220,7 +220,6 @@ public:
         match = 0;
         mismatch = 0;
         showAlign = 1;
-        refineAlign = 1;
         useScoreCutoff = false;
         maxScore = -200;
         argi = 1;
@@ -305,6 +304,7 @@ public:
         ccsFofnFileName = "";
         mapSubreadsSeparately=true;
         concordant=false;
+        refineConcordantAlignments=false;
         flankSize=40;
         useRegionTable = true;
         useHQRegionTable=true;
@@ -449,6 +449,7 @@ public:
                 cout << "ERROR, unsupported concordantTemplate: " << concordantTemplate << endl;
                 exit(1);
             }
+            if (refineConcordantAlignments) {refineAlignments = true;}
         }
 
         if (sdpFilterType > 1) {

--- a/iblasr/RegisterBlasrOptions.h
+++ b/iblasr/RegisterBlasrOptions.h
@@ -54,7 +54,6 @@ void RegisterBlasrOptions(CommandLineParser & clp, MappingParameters & params) {
     clp.RegisterFlagOption("samplePaths", (bool*) &params.samplePaths, "");
     clp.RegisterFlagOption("noStoreMapQV", &params.storeMapQV, "");
     clp.RegisterFlagOption("nowarp", (bool*) &params.nowarp, "");
-    clp.RegisterFlagOption("noRefineAlign", (bool*) &params.refineAlign, "");
     clp.RegisterFlagOption("guidedAlign", (bool*)&params.useGuidedAlign, "");
     clp.RegisterFlagOption("useGuidedAlign", (bool*)&trashbinBool, "");
     clp.RegisterFlagOption("noUseGuidedAlign", (bool*)&params.useGuidedAlign, "");
@@ -120,6 +119,7 @@ void RegisterBlasrOptions(CommandLineParser & clp, MappingParameters & params) {
     clp.RegisterFlagOption("useccsall", &params.useAllSubreadsInCcs, "");
     clp.RegisterFlagOption("extendDenovoCCSSubreads", &params.extendDenovoCCSSubreads, "");
     clp.RegisterFlagOption("noRefineAlignments", &params.refineAlignments, "");
+    clp.RegisterFlagOption("refineConcordantAlignments", &params.refineConcordantAlignments, "");
     clp.RegisterIntOption("nCandidates", &params.nCandidates, "", CommandLineParser::NonNegativeInteger);
     clp.RegisterFlagOption("useTemp", (bool*) &params.tempDirectory, "");
     clp.RegisterFlagOption("noSplitSubreads", &params.mapSubreadsSeparately, "");
@@ -323,12 +323,6 @@ const string BlasrHelp(MappingParameters & params) {
              << "               Map all subreads of a zmw (hole) to where the longest full pass subread of the zmw " << endl
              << "               aligned to. This requires to use the region table and hq regions." << endl
              << "               This option only works when reads are in base or pulse h5 format." << endl
-             << "   -concordantTemplate(mediansubread)" << endl
-             << "               Select a full pass subread of a zmw as template for concordant mapping." << endl
-             << "               longestsubread - use the longest full pass subread" << endl
-             << "               mediansubread  - use the median length full pass subread" << endl
-             << "               typicalsubread - use the second longest full pass subread if length of" << endl
-             << "                                the longest full pass subread is an outlier" << endl
              << "   -fastMaxInterval(false)" << endl
              << "               Fast search maximum increasing intervals as alignment candidates. The search " << endl
              << "               is not as exhaustive as the default, but is much faster." << endl
@@ -342,6 +336,8 @@ const string BlasrHelp(MappingParameters & params) {
              << "  Options for Refining Hits." << endl
 //             << "   -indelRate i (0.30)" << endl
 //             << "               The approximate maximum rate to allow drifting from the diagonal." <<endl << endl
+             << "   -refineConcordantAlignments(false)" << endl
+             << "               Refine concordant alignments. It slightly increases alignment accuracy at cost of time." << endl
              << "   -sdpTupleSize K (11)" << endl
              << "               Use matches of length K to speed dynamic programming alignments.  This controls" <<endl
              << "               accuracy of assigning gaps in pairwise alignments once a mapping has been found,"<<endl


### PR DESCRIPTION
This option is OFF by default.
When this option is ON,
   * concordant alignments will be refined,
   * run time is roughly 15% slower on a lambda movie
   * BLASR returns identical mapping intervals, with
     slightly better pair-wise alignments, increasing
     alignment similarity by 1%~1.5%.

Remove an unused and misleading parameter noRefineAlign.