### PR TITLE
bax2bam: auto-create PBI files(s) and updated XML output 

### DIFF
--- a/utils/bax2bam/src/Bax2Bam.cpp
+++ b/utils/bax2bam/src/Bax2Bam.cpp
@@ -120,7 +120,10 @@ bool WriteDatasetXmlOutput(const Settings& settings,
 
         // Combine the scheme and filepath and store in the dataset
         fullOutputFilepath = scheme + fullOutputFilepath;
-        resources.Add(ExternalResource("SubreadFile.SubreadBamFile",fullOutputFilepath));
+        ExternalResource mainBam{ "PacBio.SubreadFile.SubreadBamFile", fullOutputFilepath };
+        ExternalResource mainPbi{ "PacBio.Index.PacBioIndex", fullOutputFilepath + ".pbi" };
+        mainBam.ExternalResources().Add(mainPbi);
+        resources.Add(mainBam);
         dataset.ExternalResources(resources);
 
         // save to file 

--- a/utils/bax2bam/src/Bax2Bam.cpp
+++ b/utils/bax2bam/src/Bax2Bam.cpp
@@ -103,26 +103,52 @@ bool WriteDatasetXmlOutput(const Settings& settings,
         }
 
         const string scheme = "file://";
-        string fullOutputFilepath;
+        string mainBamFilepath;
 
         // If the output filename starts with a slash, assume it's the path
         if (boost::starts_with(settings.outputBamFilename, "/"))
         {
-            fullOutputFilepath = settings.outputBamFilename;
+            mainBamFilepath = settings.outputBamFilename;
         }
         else // otherwise build the path from the CWD
         { 
-            fullOutputFilepath = CurrentWorkingDir();
-            if (!fullOutputFilepath.empty())
-                fullOutputFilepath.append(1, '/');
-            fullOutputFilepath.append(settings.outputBamFilename);
+            mainBamFilepath = CurrentWorkingDir();
+            if (!mainBamFilepath.empty())
+                mainBamFilepath.append(1, '/');
+            mainBamFilepath.append(settings.outputBamFilename);
         }
 
         // Combine the scheme and filepath and store in the dataset
-        fullOutputFilepath = scheme + fullOutputFilepath;
-        ExternalResource mainBam{ "PacBio.SubreadFile.SubreadBamFile", fullOutputFilepath };
-        ExternalResource mainPbi{ "PacBio.Index.PacBioIndex", fullOutputFilepath + ".pbi" };
+        mainBamFilepath = scheme + mainBamFilepath;
+        ExternalResource mainBam{ "PacBio.SubreadFile.SubreadBamFile", mainBamFilepath };
+        ExternalResource mainPbi{ "PacBio.Index.PacBioIndex", mainBamFilepath + ".pbi" };
         mainBam.ExternalResources().Add(mainPbi);
+
+        // maybe add scraps BAM (& PBI)
+        if (!settings.scrapsBamFilename.empty()) {
+
+            string scrapsBamFilepath;
+
+            // If the output filename starts with a slash, assume it's the path
+            if (boost::starts_with(settings.scrapsBamFilename, "/"))
+            {
+                scrapsBamFilepath = settings.scrapsBamFilename;
+            }
+            else // otherwise build the path from the CWD
+            {
+                scrapsBamFilepath = CurrentWorkingDir();
+                if (!scrapsBamFilepath.empty())
+                    scrapsBamFilepath.append(1, '/');
+                scrapsBamFilepath.append(settings.scrapsBamFilename);
+            }
+
+            ExternalResource scrapsBam{ "PacBio.SubreadFile.ScrapsBamFile", scrapsBamFilepath };
+            ExternalResource scrapsPbi{ "PacBio.Index.PacBioIndex", scrapsBamFilepath + ".pbi" };
+            scrapsBam.ExternalResources().Add(scrapsPbi);
+            mainBam.ExternalResources().Add(scrapsBam);
+        }
+
+        // add resources to output dataset
         resources.Add(mainBam);
         dataset.ExternalResources(resources);
 

--- a/utils/bax2bam/src/Bax2Bam.cpp
+++ b/utils/bax2bam/src/Bax2Bam.cpp
@@ -121,8 +121,8 @@ bool WriteDatasetXmlOutput(const Settings& settings,
         // Combine the scheme and filepath and store in the dataset
         mainBamFilepath = scheme + mainBamFilepath;
         ExternalResource mainBam{ "PacBio.SubreadFile.SubreadBamFile", mainBamFilepath };
-        ExternalResource mainPbi{ "PacBio.Index.PacBioIndex", mainBamFilepath + ".pbi" };
-        mainBam.ExternalResources().Add(mainPbi);
+        FileIndex mainPbi{ "PacBio.Index.PacBioIndex", mainBamFilepath + ".pbi" };
+        mainBam.FileIndices().Add(mainPbi);
 
         // maybe add scraps BAM (& PBI)
         if (!settings.scrapsBamFilename.empty()) {
@@ -143,8 +143,8 @@ bool WriteDatasetXmlOutput(const Settings& settings,
             }
 
             ExternalResource scrapsBam{ "PacBio.SubreadFile.ScrapsBamFile", scrapsBamFilepath };
-            ExternalResource scrapsPbi{ "PacBio.Index.PacBioIndex", scrapsBamFilepath + ".pbi" };
-            scrapsBam.ExternalResources().Add(scrapsPbi);
+            FileIndex scrapsPbi{ "PacBio.Index.PacBioIndex", scrapsBamFilepath + ".pbi" };
+            scrapsBam.FileIndices().Add(scrapsPbi);
             mainBam.ExternalResources().Add(scrapsBam);
         }
 

--- a/utils/bax2bam/src/ConverterBase.h
+++ b/utils/bax2bam/src/ConverterBase.h
@@ -853,20 +853,21 @@ fallback:
     }
     settings_.movieName = (*movieNames.cbegin());
 
-    // Use the movie name to initialize the ReadGroupIds
-    settings_.readGroupId       = MakeReadGroupId(MovieName(), HeaderReadType());
-    settings_.scrapsReadGroupId = MakeReadGroupId(MovieName(), ScrapsReadType());
+    // Use the movie name to initialize the ReadGroupId
+    settings_.readGroupId = MakeReadGroupId(MovieName(), HeaderReadType());
 
     // initialize output file(s)
     if (settings_.outputBamPrefix.empty())
         settings_.outputBamPrefix = settings_.movieName;
-
     settings_.outputBamFilename = settings_.outputBamPrefix + OutputFileSuffix();
-    settings_.scrapsBamFilename = settings_.outputBamPrefix + ScrapsFileSuffix();
 
     // Separate single-output from dual-output jobs
     if (HeaderReadType() == "SUBREAD" || HeaderReadType() == "HQREGION")
     {
+        // setup scram BAM file info
+        settings_.scrapsReadGroupId = MakeReadGroupId(MovieName(), ScrapsReadType());
+        settings_.scrapsBamFilename = settings_.outputBamPrefix + ScrapsFileSuffix();
+
         // main conversion of BAX -> BAM records for dual-output jobs
         try {
             BamWriter writer(settings_.outputBamFilename, CreateHeader(HeaderReadType()));
@@ -888,6 +889,9 @@ fallback:
         PbiFile::CreateFrom(BamFile{ settings_.scrapsBamFilename });
 
     } else { 
+
+        assert(settings_.scrapsBamFilename.empty());
+
         // main conversion of BAX -> BAM records for single-output jobs
         try {
             BamWriter writer(settings_.outputBamFilename, CreateHeader(HeaderReadType()));

--- a/utils/bax2bam/src/ConverterBase.h
+++ b/utils/bax2bam/src/ConverterBase.h
@@ -41,10 +41,12 @@
 #include "IConverter.h"
 #include "Settings.h"
 #include "HDFBasReader.hpp"
-#include <pbbam/Tag.h>
-#include <pbbam/ReadGroupInfo.h>
+#include <pbbam/BamFile.h>
 #include <pbbam/BamHeader.h>
 #include <pbbam/BamWriter.h>
+#include <pbbam/PbiFile.h>
+#include <pbbam/ReadGroupInfo.h>
+#include <pbbam/Tag.h>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <libgen.h>
@@ -881,6 +883,10 @@ fallback:
             return false;
         }
 
+        // make PBI files
+        PbiFile::CreateFrom(BamFile{ settings_.outputBamFilename });
+        PbiFile::CreateFrom(BamFile{ settings_.scrapsBamFilename });
+
     } else { 
         // main conversion of BAX -> BAM records for single-output jobs
         try {
@@ -896,6 +902,9 @@ fallback:
             AddErrorMessage("failed to convert BAM file");
             return false;
         }
+
+        // make PBI file
+        PbiFile::CreateFrom(BamFile{ settings_.outputBamFilename });
     }
 
     // if we get here, return success

--- a/utils/bax2bam/tests/src/test_ccs.cpp
+++ b/utils/bax2bam/tests/src/test_ccs.cpp
@@ -70,6 +70,11 @@ TEST(CcsTest, EndToEnd_Multiple)
     const int result = RunBax2Bam(baxFilenames, "--ccs");
     EXPECT_EQ(0, result);
 
+    {   // ensure PBI exists
+        const BamFile generatedBamFile(generatedBam);
+        EXPECT_TRUE(generatedBamFile.PacBioIndexExists());
+    }
+
     // open BAX reader on original data
     HDFCCSReader<CCSSequence> baxReader;
     baxReader.IncludeField("Basecall");
@@ -244,6 +249,7 @@ cleanup:
         // cleanup
         baxReader.Close();
         RemoveFile(generatedBam);
+        RemoveFile(generatedBam + ".pbi");
 
     }); // EXPECT_NO_THROW
 }

--- a/utils/bax2bam/tests/src/test_hqregions.cpp
+++ b/utils/bax2bam/tests/src/test_hqregions.cpp
@@ -70,6 +70,12 @@ TEST(HqRegionsTest, EndToEnd_Single)
     const int result = RunBax2Bam(baxFilenames, "--hqregion");
     EXPECT_EQ(0, result);
 
+    {   // ensure PBIs exist
+        const BamFile generatedBamFile(generatedBam);
+        const BamFile scrapsBamFile(scrapBam);
+        EXPECT_TRUE(generatedBamFile.PacBioIndexExists());
+        EXPECT_TRUE(scrapsBamFile.PacBioIndexExists());
+    }
 
     // open BAX reader on original data
     HDFBasReader baxReader;
@@ -445,5 +451,7 @@ TEST(HqRegionsTest, EndToEnd_Single)
         baxReader.Close();
         RemoveFile(generatedBam);
         RemoveFile(scrapBam);
+        RemoveFile(generatedBam + ".pbi");
+        RemoveFile(scrapBam + ".pbi");
     });
 }

--- a/utils/bax2bam/tests/src/test_polymerase.cpp
+++ b/utils/bax2bam/tests/src/test_polymerase.cpp
@@ -66,6 +66,11 @@ TEST(PolymeraseTest, EndToEnd_Single)
     const int result = RunBax2Bam(baxFilenames, "--polymeraseread");
     EXPECT_EQ(0, result);
 
+    {   // ensure PBI exists
+        const BamFile generatedBamFile(generatedBam);
+        EXPECT_TRUE(generatedBamFile.PacBioIndexExists());
+    }
+
     // open BAX reader on original data
     HDFBasReader baxReader;
     baxReader.IncludeField("Basecall");
@@ -260,6 +265,7 @@ TEST(PolymeraseTest, EndToEnd_Single)
         // cleanup
         baxReader.Close();
         RemoveFile(generatedBam);
+        RemoveFile(generatedBam + ".pbi");
 
     }); // EXPECT_NO_THROW
 }

--- a/utils/bax2bam/tests/src/test_subreads.cpp
+++ b/utils/bax2bam/tests/src/test_subreads.cpp
@@ -169,6 +169,13 @@ TEST(SubreadsTest, EndToEnd_Multiple)
     const int result = RunBax2Bam(baxFilenames, "--subread");
     EXPECT_EQ(0, result);
 
+    {   // ensure PBIs exist
+        const BamFile generatedBamFile(generatedBam);
+        const BamFile scrapsBamFile(scrapBam);
+        EXPECT_TRUE(generatedBamFile.PacBioIndexExists());
+        EXPECT_TRUE(scrapsBamFile.PacBioIndexExists());
+    }
+
     // open BAX reader on original data
     HDFBasReader baxReader;
     baxReader.IncludeField("Basecall");
@@ -432,6 +439,8 @@ cleanup:
         baxReader.Close();
         RemoveFile(generatedBam);
         RemoveFile(scrapBam);
+        RemoveFile(generatedBam + ".pbi");
+        RemoveFile(scrapBam + ".pbi");
 
     }); // EXPECT_NO_THROW
 }


### PR DESCRIPTION
Added: auto-creation of PBI files(s) for bax2bam output - main BAM and scraps BAM (if applicable).

Fixed: DatasetXML output now also contains all of these child files (PBI files & scraps BAM). 

bugzilla: 29086, 29829