### PR TITLE
PacBioBam3.0.2 update

### DIFF
--- a/utils/bax2bam/src/IConverter.cpp
+++ b/utils/bax2bam/src/IConverter.cpp
@@ -64,14 +64,16 @@ BamHeader IConverter::CreateHeader(const string& modeString)
     //     pb:<current PacBio BAM spec version>
     header.Version("1.5")
           .SortOrder("unknown")
-          .PacBioBamVersion("3.0.1");
+          .PacBioBamVersion("3.0.2");
 
     // @RG ID: <read group ID>
     //     DS: READTYPE=<HQREGION|POLYMERASE|SUBREAD>[;<Tag Manifest>;BINDINGKIT=<foo>;SEQUENCINGKIT=<bar>;BASECALLERVERSION=<42>]
     //     PL: PACBIO
     //     PU: <movieName>
     //
-    ReadGroupInfo rg(settings_.movieName, modeString);
+    const PlatformModelType platform = settings_.isSequelInput_ ? PlatformModelType::SEQUEL
+                                                                : PlatformModelType::RS;
+    ReadGroupInfo rg(settings_.movieName, modeString, platform);
     rg.BindingKit(bindingKit_)
       .SequencingKit(sequencingKit_)
       .BasecallerVersion(basecallerVersion_)

--- a/utils/bax2bam/src/Settings.cpp
+++ b/utils/bax2bam/src/Settings.cpp
@@ -45,10 +45,6 @@ using namespace std;
 
 namespace internal {
 
-static inline
-bool StartsWith(const string& input, const string& query)
-{ return input.find(query) != string::npos; }
-
 static
 vector<string> BaxFilenamesFromXml(const string& xmlFilename)
 {

--- a/utils/bax2bam/src/Settings.cpp
+++ b/utils/bax2bam/src/Settings.cpp
@@ -125,9 +125,11 @@ const char* Settings::Option::pulseFeatures_  = "pulseFeatures";
 const char* Settings::Option::subreadMode_    = "subreadMode";
 const char* Settings::Option::ccsMode_        = "ccsMode";
 const char* Settings::Option::outputXml_      = "outputXml";
+const char* Settings::Option::sequelPlatform_ = "sequelPlatform";
 
 Settings::Settings(void)
     : mode(Settings::SubreadMode)
+    , isSequelInput_(false)
     , usingDeletionQV(true)
     , usingDeletionTag(true)
     , usingInsertionQV(true)
@@ -221,6 +223,10 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
     else
         settings.errors_.push_back("multiple modes selected");
 
+    // platform
+    settings.isSequelInput_ = options.is_set(Settings::Option::sequelPlatform_) ? options.get(Settings::Option::sequelPlatform_)
+                                                                                : false;
+
     // frame data encoding
     settings.losslessFrames = options.is_set(Settings::Option::losslessFrames_) ? options.get(Settings::Option::losslessFrames_)
                                                                                 : false;
@@ -267,10 +273,13 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
     else
         modeString = "ccs";
 
+    string platformString = settings.isSequelInput_ ? "Sequel" : "RS";
+
     cerr << "CommandLine: " << settings.program << " " << settings.args << endl
          << "Description: " << settings.description << endl
          << "Version:     " << settings.version << endl
          << "Mode:        " << modeString << endl
+         << "Platform:    " << platformString << endl
          << "DeletionQV?:      " << ( settings.usingDeletionQV ? "yes" : "no" ) << endl
          << "DeletionTag?:     " << ( settings.usingDeletionTag ? "yes" : "no" ) << endl
          << "InsertionQV?:     " << ( settings.usingInsertionQV ? "yes" : "no" ) << endl

--- a/utils/bax2bam/src/Settings.h
+++ b/utils/bax2bam/src/Settings.h
@@ -37,7 +37,6 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include "pbbam/ReadGroupInfo.h"
 #include <string>
 #include <vector>
 

--- a/utils/bax2bam/src/Settings.h
+++ b/utils/bax2bam/src/Settings.h
@@ -37,6 +37,7 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include "pbbam/ReadGroupInfo.h"
 #include <string>
 #include <vector>
 
@@ -63,6 +64,7 @@ public:
         static const char* subreadMode_;
         static const char* ccsMode_;
         static const char* outputXml_;
+        static const char* sequelPlatform_;
     };
 
 public:
@@ -84,6 +86,9 @@ public:
 
     // mode
     Mode mode;
+
+    // platform
+    bool isSequelInput_;
 
     // features
     bool usingDeletionQV;

--- a/utils/bax2bam/src/main.cpp
+++ b/utils/bax2bam/src/main.cpp
@@ -49,7 +49,7 @@ int main(int argc, char* argv[])
     optparse::OptionParser parser;
     parser.description("bax2bam converts the legacy PacBio basecall format (bax.h5) into the BAM basecall format.");
     parser.prog("bax2bam");
-    parser.version("0.0.2");
+    parser.version("0.0.3");
     parser.add_version_option(true);
     parser.add_help_option(true);
 
@@ -76,6 +76,13 @@ int main(int argc, char* argv[])
            .help("Explicit output XML name. If none provided via this arg, bax2bam will use -o prefix (<prefix>.dataset.xml). "
                  "If that is not specified either, the output XML filename will be <moviename>.dataset.xml");
     parser.add_option_group(ioGroup);
+
+    auto platformGroup = optparse::OptionGroup(parser, "Input sequencing platform");
+    platformGroup.add_option("--sequel-input")
+                 .dest(Settings::Option::sequelPlatform_)
+                 .action("store_true")
+                 .help("Specify that input data is from Sequel. "
+                       "bax2bam will assume RS unless this option is specified");
 
     auto modeGroup = optparse::OptionGroup(parser, "Output read types (mutually exclusive:)");
     modeGroup.add_option("--subread")


### PR DESCRIPTION
Brings bax2bam up to compliance with PacBioBam spec v3.0.2 (explicit platform model tag in read groups). bax2bam will assume RS input unless the new "--sequel-input" option is specified.

(bug 30855)