### PR TITLE
fixed PacBioBAM version number in test code

### DIFF
--- a/utils/bax2bam/tests/src/test_ccs.cpp
+++ b/utils/bax2bam/tests/src/test_ccs.cpp
@@ -104,7 +104,7 @@ TEST(CcsTest, EndToEnd_Multiple)
         const BamHeader& header = bamFile.Header();
         EXPECT_EQ(string("1.5"),     header.Version());
         EXPECT_EQ(string("unknown"), header.SortOrder());
-        EXPECT_EQ(string("3.0.1"),   header.PacBioBamVersion());
+        EXPECT_EQ(string("3.0.2"),   header.PacBioBamVersion());
         EXPECT_TRUE(header.Sequences().empty());
         EXPECT_TRUE(header.Comments().empty());
         ASSERT_FALSE(header.Programs().empty());

--- a/utils/bax2bam/tests/src/test_hqregions.cpp
+++ b/utils/bax2bam/tests/src/test_hqregions.cpp
@@ -107,7 +107,7 @@ TEST(HqRegionsTest, EndToEnd_Single)
         const BamHeader& header = bamFile.Header();
         EXPECT_EQ(string("1.5"),     header.Version());
         EXPECT_EQ(string("unknown"), header.SortOrder());
-        EXPECT_EQ(string("3.0.1"),   header.PacBioBamVersion());
+        EXPECT_EQ(string("3.0.2"),   header.PacBioBamVersion());
         EXPECT_TRUE(header.Sequences().empty());
         EXPECT_TRUE(header.Comments().empty());
         ASSERT_FALSE(header.Programs().empty());
@@ -264,7 +264,7 @@ TEST(HqRegionsTest, EndToEnd_Single)
         const BamHeader& header = bamFile.Header();
         EXPECT_EQ(string("1.5"),     header.Version());
         EXPECT_EQ(string("unknown"), header.SortOrder());
-        EXPECT_EQ(string("3.0.1"),   header.PacBioBamVersion());
+        EXPECT_EQ(string("3.0.2"),   header.PacBioBamVersion());
         EXPECT_TRUE(header.Sequences().empty());
         EXPECT_TRUE(header.Comments().empty());
         ASSERT_FALSE(header.Programs().empty());

--- a/utils/bax2bam/tests/src/test_polymerase.cpp
+++ b/utils/bax2bam/tests/src/test_polymerase.cpp
@@ -88,7 +88,7 @@ TEST(PolymeraseTest, EndToEnd_Single)
         const BamHeader& header = bamFile.Header();
         EXPECT_EQ(string("1.5"),     header.Version());
         EXPECT_EQ(string("unknown"), header.SortOrder());
-        EXPECT_EQ(string("3.0.1"),   header.PacBioBamVersion());
+        EXPECT_EQ(string("3.0.2"),   header.PacBioBamVersion());
         EXPECT_TRUE(header.Sequences().empty());
         EXPECT_TRUE(header.Comments().empty());
         ASSERT_FALSE(header.Programs().empty());

--- a/utils/bax2bam/tests/src/test_subreads.cpp
+++ b/utils/bax2bam/tests/src/test_subreads.cpp
@@ -201,7 +201,7 @@ TEST(SubreadsTest, EndToEnd_Multiple)
         const BamHeader& header = bamFile.Header();
         EXPECT_EQ(string("1.5"),     header.Version());
         EXPECT_EQ(string("unknown"), header.SortOrder());
-        EXPECT_EQ(string("3.0.1"),   header.PacBioBamVersion());
+        EXPECT_EQ(string("3.0.2"),   header.PacBioBamVersion());
         EXPECT_TRUE(header.Sequences().empty());
         EXPECT_TRUE(header.Comments().empty());
         ASSERT_FALSE(header.Programs().empty());


### PR DESCRIPTION
Adding test source code changes I missed in the earlier update to PacBioBAM v3.0.2 