### PR TITLE
exclude non-sequencing ZMWs

### DIFF
--- a/utils/bax2bam/CMakeLists.txt
+++ b/utils/bax2bam/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 2.8)
 # project version
 set(Bax2Bam_MAJOR_VERSION 0)
 set(Bax2Bam_MINOR_VERSION 0)
-set(Bax2Bam_PATCH_VERSION 7)
+set(Bax2Bam_PATCH_VERSION 8)
 set(Bax2Bam_VERSION
   "${Bax2Bam_MAJOR_VERSION}.${Bax2Bam_MINOR_VERSION}.${Bax2Bam_PATCH_VERSION}"
 )

--- a/utils/bax2bam/src/CcsConverter.cpp
+++ b/utils/bax2bam/src/CcsConverter.cpp
@@ -33,9 +33,6 @@ bool CcsConverter::ConvertFile(HdfCcsReader* reader,
 {
     assert(reader);
 
-    // initialize with default values (shared across all unmapped subreads)
-    BamRecordImpl bamRecord;
-
     // initialize read scores
     InitReadScores(reader);
 
@@ -44,7 +41,7 @@ bool CcsConverter::ConvertFile(HdfCcsReader* reader,
     while (reader->GetNext(smrtRecord)) {
 
         // Skip empty records
-        if (smrtRecord.length == 0)
+        if ((smrtRecord.length == 0) || !IsSequencingZmw(smrtRecord))
             continue;
 
         // attempt convert BAX to BAM

--- a/utils/bax2bam/src/IConverter.cpp
+++ b/utils/bax2bam/src/IConverter.cpp
@@ -36,7 +36,7 @@ BamHeader IConverter::CreateHeader(const string& modeString)
     //     PL: PACBIO
     //     PU: <movieName>
     //
-    const PlatformModelType platform = settings_.isSequelInput_ ? PlatformModelType::SEQUEL
+    const PlatformModelType platform = settings_.isSequelInput ? PlatformModelType::SEQUEL
                                                                 : PlatformModelType::RS;
     ReadGroupInfo rg(settings_.movieName, modeString, platform);
     rg.BindingKit(bindingKit_)

--- a/utils/bax2bam/src/PolymeraseReadConverter.cpp
+++ b/utils/bax2bam/src/PolymeraseReadConverter.cpp
@@ -17,9 +17,6 @@ bool PolymeraseReadConverter::ConvertFile(HDFBasReader* reader,
 {
     assert(reader);
 
-    // initialize BamRecord with default values (shared across all reads)
-    PacBio::BAM::BamRecordImpl bamRecord;
-
     // initialize read scores
     InitReadScores(reader);
 
@@ -28,7 +25,7 @@ bool PolymeraseReadConverter::ConvertFile(HDFBasReader* reader,
     while (reader->GetNext(smrtRecord)) {
 
         // Skip empty records
-        if (smrtRecord.length == 0)
+        if ((smrtRecord.length == 0) || !IsSequencingZmw(smrtRecord))
             continue;
 
         // attempt convert BAX to BAM

--- a/utils/bax2bam/src/Settings.cpp
+++ b/utils/bax2bam/src/Settings.cpp
@@ -85,12 +85,14 @@ const char* Settings::Option::polymeraseMode_ = "polymeraseMode";
 const char* Settings::Option::pulseFeatures_  = "pulseFeatures";
 const char* Settings::Option::subreadMode_    = "subreadMode";
 const char* Settings::Option::ccsMode_        = "ccsMode";
+const char* Settings::Option::internalMode_   = "internalMode";
 const char* Settings::Option::outputXml_      = "outputXml";
 const char* Settings::Option::sequelPlatform_ = "sequelPlatform";
 
 Settings::Settings(void)
     : mode(Settings::SubreadMode)
-    , isSequelInput_(false)
+    , isInternal(false)
+    , isSequelInput(false)
     , usingDeletionQV(true)
     , usingDeletionTag(true)
     , usingInsertionQV(true)
@@ -151,7 +153,7 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
     }
 
     if (settings.inputBaxFilenames.empty())
-        settings.errors_.push_back("missing input BAX files.");
+        settings.errors.push_back("missing input BAX files.");
 
     // mode
     const bool isSubreadMode =
@@ -182,10 +184,14 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
         if (isCCS)            settings.mode = Settings::CCSMode;
     }
     else
-        settings.errors_.push_back("multiple modes selected");
+        settings.errors.push_back("multiple modes selected");
+
+    // internal file mode
+    settings.isInternal = options.is_set(Settings::Option::internalMode_) ? options.get(Settings::Option::internalMode_)
+                                                                          : false;
 
     // platform
-    settings.isSequelInput_ = options.is_set(Settings::Option::sequelPlatform_) ? options.get(Settings::Option::sequelPlatform_)
+    settings.isSequelInput = options.is_set(Settings::Option::sequelPlatform_) ? options.get(Settings::Option::sequelPlatform_)
                                                                                 : false;
 
     // frame data encoding
@@ -218,7 +224,7 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
             else if (feature == "SubstitutionQV")  settings.usingSubstitutionQV = true;
             else if (feature == "SubstitutionTag") settings.usingSubstitutionTag = true;
             else
-                settings.errors_.push_back(string("unknown pulse feature: ") + feature);
+                settings.errors.push_back(string("unknown pulse feature: ") + feature);
         }
     }
 

--- a/utils/bax2bam/src/Settings.h
+++ b/utils/bax2bam/src/Settings.h
@@ -27,6 +27,7 @@ public:
         static const char* pulseFeatures_;
         static const char* subreadMode_;
         static const char* ccsMode_;
+        static const char* internalMode_;
         static const char* outputXml_;
         static const char* sequelPlatform_;
     };
@@ -50,9 +51,10 @@ public:
 
     // mode
     Mode mode;
+    bool isInternal;
 
     // platform
-    bool isSequelInput_;
+    bool isSequelInput;
 
     // features
     bool usingDeletionQV;
@@ -79,7 +81,7 @@ public:
     std::string scrapsReadGroupId;
 
     // command line parsing
-    std::vector<std::string> errors_;
+    std::vector<std::string> errors;
 };
 
 #endif // SETTINGS_H

--- a/utils/bax2bam/src/main.cpp
+++ b/utils/bax2bam/src/main.cpp
@@ -14,7 +14,7 @@ int main(int argc, char* argv[])
     optparse::OptionParser parser;
     parser.description("bax2bam converts the legacy PacBio basecall format (bax.h5) into the BAM basecall format.");
     parser.prog("bax2bam");
-    parser.version("0.0.3");
+    parser.version("0.0.8");
     parser.add_version_option(true);
     parser.add_help_option(true);
 
@@ -49,24 +49,24 @@ int main(int argc, char* argv[])
                  .help("Specify that input data is from Sequel. "
                        "bax2bam will assume RS unless this option is specified");
 
-    auto modeGroup = optparse::OptionGroup(parser, "Output read types (mutually exclusive:)");
-    modeGroup.add_option("--subread")
-             .dest(Settings::Option::subreadMode_)
-             .action("store_true")
-             .help("Output subreads (default)");
-    modeGroup.add_option("--hqregion")
-             .dest(Settings::Option::hqRegionMode_)
-             .action("store_true")
-             .help("Output HQ regions");
-    modeGroup.add_option("--polymeraseread")
-             .dest(Settings::Option::polymeraseMode_)
-             .action("store_true")
-             .help("Output full polymerase read");
-    modeGroup.add_option("--ccs")
-             .dest(Settings::Option::ccsMode_)
-             .action("store_true")
-             .help("Output CCS sequences");
-    parser.add_option_group(modeGroup);
+    auto readModeGroup = optparse::OptionGroup(parser, "Output read types (mutually exclusive)");
+    readModeGroup.add_option("--subread")
+                 .dest(Settings::Option::subreadMode_)
+                 .action("store_true")
+                 .help("Output subreads (default)");
+    readModeGroup.add_option("--hqregion")
+                 .dest(Settings::Option::hqRegionMode_)
+                 .action("store_true")
+                 .help("Output HQ regions");
+    readModeGroup.add_option("--polymeraseread")
+                 .dest(Settings::Option::polymeraseMode_)
+                 .action("store_true")
+                 .help("Output full polymerase read");
+    readModeGroup.add_option("--ccs")
+                 .dest(Settings::Option::ccsMode_)
+                 .action("store_true")
+                 .help("Output CCS sequences");
+    parser.add_option_group(readModeGroup);
 
     auto featureGroup = optparse::OptionGroup(parser, "Pulse feature options");
     featureGroup.group_description("Configure pulse features in the output BAM. Supported features include:\n"
@@ -92,11 +92,21 @@ int main(int argc, char* argv[])
                 .help("Store full, 16-bit IPD/PulseWidth data, instead of (default) downsampled, 8-bit encoding.");
     parser.add_option_group(featureGroup);
 
+    auto bamModeGroup = optparse::OptionGroup(parser, "Output BAM file type");
+    bamModeGroup.add_option("--internal")
+                .dest(Settings::Option::internalMode_)
+                .action("store_true")
+                .help("Output BAMs in internal mode. Currently this indicates that "
+                      "non-sequencing ZMWs should be included in the output scraps "
+                      "BAM file, if applicable."
+                      );
+    parser.add_option_group(bamModeGroup);
+
     // parse command line
     Settings settings = Settings::FromCommandLine(parser, argc, argv);
-    if (!settings.errors_.empty()) {
+    if (!settings.errors.empty()) {
         cerr << endl;
-        for (const auto e : settings.errors_)
+        for (const auto e : settings.errors)
             cerr << "ERROR: " << e << endl;
         cerr << endl;
         parser.print_help();


### PR DESCRIPTION
bax2bam v0.0.8: exclude non-sequencing ZMWs from output BAMs. These records can be retained and stored in the scraps BAM file, by setting the (new) '--internal' mode command-line option. [bug 30416]