### PR TITLE
Fix cram tests, remove polymerase.bam options

### DIFF
--- a/utils/bam2bax/src/Bam2BaxConverterImpl.hpp
+++ b/utils/bam2bax/src/Bam2BaxConverterImpl.hpp
@@ -50,20 +50,6 @@ bool Bam2BaxConverter<T_HDFWRITER>::ConvertFile(void) {
         }
         if (not settings_.ignoreQV) writer.WriteFakeDataSets();
         for (auto error: writer.Errors()) { AddErrorMessage(error); }
-    } else if (not settings_.polymeraseBamFilename.empty()) {
-        // Read polymerase reads from polymerase.bam directly.
-        PacBio::BAM::EntireFileQuery query(bamfile);
-        for (auto record: query) {
-            SMRTSequence smrt;
-            smrt.Copy(record, true);
-            RegionAnnotation ra(record.HoleNumber(), 
-                                RegionTypeAdapter::ToRegionTypeIndex(PacBio::BAM::VirtualRegionType::HQREGION, regionTypes),
-                                0, 0, 0);
-            std::vector<RegionAnnotation> ras({ra});
-            if (not writer.WriteOneZmw(smrt, ras) or not writer.Errors().empty()) { break; }
-        }
-        if (not settings_.ignoreQV) writer.WriteFakeDataSets();
-        for (auto error: writer.Errors()) { AddErrorMessage(error); }
     }
             
     return errors_.empty();

--- a/utils/bam2bax/src/Bam2BaxMain.cpp
+++ b/utils/bam2bax/src/Bam2BaxMain.cpp
@@ -21,8 +21,8 @@ int main(int argc, char* argv[])
     auto ioGroup = optparse::OptionGroup(parser, "Input/output files");
     ioGroup.add_option("")
            .dest(Settings::Option::input_)
-	       .metavar("movie.subreads.bam movie.scraps.bam | movie.polymerase.bam") 
-           .help("Input a movie.polymerase.bam. Or a movie.subreads.bam and a movie.scraps.bam");
+	       .metavar("movie.subreads.bam movie.scraps.bam") 
+           .help("A movie.subreads.bam and a movie.scraps.bam");
     ioGroup.add_option("--trace")
             .dest(Settings::Option::trace_)
             .metavar("movie.trc.h5")

--- a/utils/bam2bax/src/Bam2PlxMain.cpp
+++ b/utils/bam2bax/src/Bam2PlxMain.cpp
@@ -21,8 +21,8 @@ int main(int argc, char* argv[])
     auto ioGroup = optparse::OptionGroup(parser, "Input/output files");
     ioGroup.add_option("")
            .dest(Settings::Option::input_)
-	       .metavar("movie.subreads.bam movie.scraps.bam | movie.polymerase.bam") 
-           .help("Input a movie.polymerase.bam. Or a movie.subreads.bam and a movie.scraps.bam");
+	       .metavar("movie.subreads.bam movie.scraps.bam") 
+           .help("A movie.subreads.bam and a movie.scraps.bam");
     ioGroup.add_option("-o")
            .dest(Settings::Option::output_)
 	       .metavar("STRING")

--- a/utils/bam2bax/src/Converter.cpp
+++ b/utils/bam2bax/src/Converter.cpp
@@ -7,8 +7,6 @@ Converter::Converter(Settings const& settings)
 
     std::string infn = settings_.subreadsBamFilename;
 
-    if (infn.empty()) infn = settings_.polymeraseBamFilename;
-
     bamfile_ = new PacBio::BAM::BamFile(infn);
     PacBio::BAM::BamHeader bamheader = bamfile_->Header();
 
@@ -72,20 +70,6 @@ bool Converter::Run() {
             std::vector<RegionAnnotation> ras = RegionsAdapter::ToRegionAnnotations(record, regionTypes);
             if (not writer_->WriteOneZmw(smrt, ras) or not writer_->Errors().empty()) { break; }
             writer_->Flush();
-        }
-        if (not settings_.ignoreQV) writer_->WriteFakeDataSets();
-        for (auto error: writer_->Errors()) { AddErrorMessage(error); }
-    } else if (not settings_.polymeraseBamFilename.empty()) {
-        // Read polymerase reads from polymerase.bam directly.
-        PacBio::BAM::EntireFileQuery query(*bamfile_);
-        for (auto record: query) {
-            SMRTSequence smrt;
-            smrt.Copy(record, true);
-            RegionAnnotation ra(record.HoleNumber(), 
-                                RegionTypeAdapter::ToRegionTypeIndex(PacBio::BAM::VirtualRegionType::HQREGION, regionTypes),
-                                0, 0, 0);
-            std::vector<RegionAnnotation> ras({ra});
-            if (not writer_->WriteOneZmw(smrt, ras) or not writer_->Errors().empty()) { break; }
         }
         if (not settings_.ignoreQV) writer_->WriteFakeDataSets();
         for (auto error: writer_->Errors()) { AddErrorMessage(error); }

--- a/utils/bam2bax/src/Settings.cpp
+++ b/utils/bam2bax/src/Settings.cpp
@@ -154,11 +154,7 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
 
     // input
     settings.inputBamFilenames = parser.args();
-    if (settings.inputBamFilenames.size() == 1) {
-        settings.polymeraseBamFilename = settings.inputBamFilenames[0];
-        if (settings.polymeraseBamFilename.find("polymerase.bam") == std::string::npos)
-            settings.errors_.push_back("missing input *.polymerase.bam.");
-    } else if (settings.inputBamFilenames.size() == 2) {
+    if (settings.inputBamFilenames.size() == 2) {
         settings.subreadsBamFilename = settings.inputBamFilenames[0];
         settings.scrapsBamFilename   = settings.inputBamFilenames[1];
         if (settings.subreadsBamFilename.find("subreads.bam") == std::string::npos)
@@ -166,7 +162,7 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
         if (settings.scrapsBamFilename.find("scraps.bam") == std::string::npos)
             settings.errors_.push_back("missing input *.scraps.bam.");
     } else {
-        settings.errors_.push_back("missing input (polymerase.bam or subreads+scraps.bam.");
+        settings.errors_.push_back("missing input subreads+scraps.bam.");
     }
 
     if (options.is_set(Settings::Option::trace_)) {
@@ -180,8 +176,6 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
     if (settings.outputBaxPrefix.empty()) { // if output prefix not set.
         if (not settings.subreadsBamFilename.empty()) {
             settings.outputBaxPrefix = internal::GetMovienameFromFilename(settings.subreadsBamFilename);
-        } else if (not settings.polymeraseBamFilename.empty()) {
-            settings.outputBaxPrefix = internal::GetMovienameFromFilename(settings.polymeraseBamFilename);
         }
     }
 
@@ -219,8 +213,6 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
          cerr << " subreads  : " << settings.subreadsBamFilename << endl;
     if (not settings.scrapsBamFilename.empty())
          cerr << " scraps    : " << settings.scrapsBamFilename << endl;
-    if (not settings.polymeraseBamFilename.empty())
-         cerr << " polymerase: " << settings.polymeraseBamFilename << endl;
     if (not settings.traceFilename.empty())
          cerr << " trace     : " << settings.traceFilename << endl;
     cerr << "Output h5  : " << settings.outputBaxFilename << endl

--- a/utils/bam2bax/tests/cram/bam2bax.t
+++ b/utils/bam2bax/tests/cram/bam2bax.t
@@ -65,18 +65,6 @@ diff input with output
   $ diff $I_SR_SAM.tmp $O_SR_SAM.tmp || echo I.subreads.bam and O.subreads.bam are not identical
   $ diff $I_SC_SAM.tmp $O_SC_SAM.tmp || echo I.subreads.bam and O.subreads.bam are not identical
 
-
-polymerase.bam to bax.h5
-  $ $BAM2BAX /pbi/dept/secondary/siv/testdata/bam2bax/bam2plx/small.polymerase.bam -o Analysis_Results/polymerase 1>/dev/null 2>/dev/null && echo $?
-  0
-
-  $ h5ls -r Analysis_Results/polymerase.bax.h5 |grep PulseData/Regions |wc -l
-  1
-
-  $ h5dump -d PulseData/Regions Analysis_Results/polymerase.bax.h5 |grep '133229, 2, 0, 0, 0' |wc -l
-  1
-
-
 ZMW with no HQ region
   $ $BAM2BAX /pbi/dept/secondary/siv/testdata/bam2bax/all_lq/all_lq.subreads.bam /pbi/dept/secondary/siv/testdata/bam2bax/all_lq/all_lq.scraps.bam -o Analysis_Results/all_lq 1>/dev/null 2>/dev/null && echo $?
   0

--- a/utils/bam2bax/tests/cram/bam2plx.t
+++ b/utils/bam2bax/tests/cram/bam2plx.t
@@ -115,15 +115,15 @@ Check PulseCalls/MeanSignal
      DATATYPE  H5T_STD_U16LE
      DATASPACE  SIMPLE { ( 15581, 4 ) / ( H5S_UNLIMITED, 4 ) }
      DATA {
-     (0,0): 0, 0, 0, 112,
-     (1,0): 0, 75, 0, 0,
-     (2,0): 0, 0, 0, 65,
-     (3,0): 0, 60, 0, 0,
-     (4,0): 0, 0, 0, 62,
+     (0,0): 0, 0, 0, 11,
+     (1,0): 0, 8, 0, 0,
+     (2,0): 0, 0, 0, 7,
+     (3,0): 0, 6, 0, 0,
+     (4,0): 0, 0, 0, 6,
 
 Check PulseCalls/MidSignal
   $ h5dump -d /PulseData/PulseCalls/MidSignal $O_PLX_H5 |grep "(0):"
-     (0): 0, 0, 0, 51, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 82, 0, 82,
+     (0): 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 8, 0,
 
 Check PulseCalls/WidthInFrames
   $ h5dump -d /PulseData/PulseCalls/WidthInFrames $O_PLX_H5 | grep "(0):"


### PR DESCRIPTION
bam2plx.t was broken due to a change in the PK value API.  Fixed the
values.  Also removed the old polymerase.bam in favor of the scraps +
subreads file.