### PR TITLE
Run git from SRCDIR

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ foo:
 	echo $(MAKEFILE_LIST)
 	echo ${SRCDIR}
 
-GET_SHA1 := $(shell git describe --always --dirty='*')
+GET_SHA1 := $(shell git -C ${SRCDIR} describe --always --dirty='*')
 CXXFLAGS += -O3 -g -DSHA1_7=\"${GET_SHA1}\"
 CXXOPTS += \
 		   -std=c++0x -pedantic \


### PR DESCRIPTION
Observed using mobs:
```
make: Entering directory home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/build'
/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/prebuilt.out/3.x/gcc/gcc-4.8.4/libc-2.5/../ccache-3.2.2/bin/g++ -O3
 -g -DSHA1_7=\"fbf1205*\"
-std=c++0x -pedantic -Wall -Wextra -Wno-div-by-zero -Wno-overloaded-virtual -MMD -MP -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fno-omit-frame-pointer  -I/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/libblasr/include/blasr/alignment -I/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/libpbihdf/include/blasr/hdf -I/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/libpbdata/include/blasr/pbdata -isystem/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/pbbam/include -isystem/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/hdf5/include -isystem/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/htslib/include -isystem/home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/_output/modulebuilds/bioinformatics/ext/pi/blasr/_output/deplinks/boost/include  -c -o Blasr.o /home/UNIXHOME/cdunn/repo/pb/smrtanalysis-client/smrtanalysis/bioinformatics/ext/pi/blasr/Blasr.cpp
```
I'm not sure why there is a `*` after the SHA1, but I guess this is what you want.