### PR TITLE
Disabled chemistry triple check for bax2bam.

### DIFF
--- a/utils/bax2bam/src/ConverterBase.h
+++ b/utils/bax2bam/src/ConverterBase.h
@@ -818,17 +818,7 @@ bool ConverterBase<RecordType, HdfReader>::LoadChemistryFromMetadataXML(
         sequencingKit_     = pt.get<std::string>("Metadata.SequencingKit.PartNumber");
         basecallerVersion_ = pt.get<std::string>("Metadata.InstCtrlVer");
 
-        // throws if invalid chemistry triple
-        // we'll take the opportunity to exit early with error message
-        using PacBio::BAM::ReadGroupInfo;
-        auto chemistryCheck = ReadGroupInfo::SequencingChemistryFromTriple(bindingKit_,
-                                                                           sequencingKit_,
-                                                                           basecallerVersion_);
         return true;
-    }
-    catch (PacBio::BAM::InvalidSequencingChemistryException& e) {
-        AddErrorMessage(e.what());
-        return false;
     }
     catch (...)
     { }


### PR DESCRIPTION
Causing problems with older RSII data, whose chemistry triples do not have entries in pbbam's ChemistryTable. 

Considering that bax2bam is designed specifically to work with those older files, removing this check seems a reasonable way to go. 

Thoughts?