### PR TITLE
Fixed typo in XML output handling 

### DIFF
--- a/utils/bax2bam/src/Bax2Bam.cpp
+++ b/utils/bax2bam/src/Bax2Bam.cpp
@@ -58,6 +58,7 @@ bool WriteDatasetXmlOutput(const Settings& settings,
                 outputBamFileType = "PacBio.SubreadFile.SubreadBamFile";
                 outputScrapsFileType = "PacBio.SubreadFile.ScrapsBamFile";
                 outputXmlSuffix = ".subreadset.xml";
+                break;
             }
 
             case Settings::CCSMode :


### PR DESCRIPTION
A missing break statement caused subread mode setup to fall through & generate ccs read set XML instead.

@natechols - looks like this should do the trick