### PR TITLE
added --allowUnrecognizedChemistryTriple option to bax2bam

### DIFF
--- a/utils/bax2bam/src/ConverterBase.h
+++ b/utils/bax2bam/src/ConverterBase.h
@@ -818,12 +818,16 @@ bool ConverterBase<RecordType, HdfReader>::LoadChemistryFromMetadataXML(
         sequencingKit_     = pt.get<std::string>("Metadata.SequencingKit.PartNumber");
         basecallerVersion_ = pt.get<std::string>("Metadata.InstCtrlVer");
 
-        // throws if invalid chemistry triple
-        // we'll take the opportunity to exit early with error message
-        using PacBio::BAM::ReadGroupInfo;
-        auto chemistryCheck = ReadGroupInfo::SequencingChemistryFromTriple(bindingKit_,
-                                                                           sequencingKit_,
-                                                                           basecallerVersion_);
+        if (!settings_.isIgnoringChemistryCheck) {
+
+            // throws if invalid chemistry triple
+            // we'll take the opportunity to exit early with error message
+            using PacBio::BAM::ReadGroupInfo;
+            auto chemistryCheck = ReadGroupInfo::SequencingChemistryFromTriple(bindingKit_,
+                                                                               sequencingKit_,
+                                                                               basecallerVersion_);
+        }
+
         return true;
     }
     catch (PacBio::BAM::InvalidSequencingChemistryException& e) {

--- a/utils/bax2bam/src/Settings.cpp
+++ b/utils/bax2bam/src/Settings.cpp
@@ -88,11 +88,13 @@ const char* Settings::Option::ccsMode_        = "ccsMode";
 const char* Settings::Option::internalMode_   = "internalMode";
 const char* Settings::Option::outputXml_      = "outputXml";
 const char* Settings::Option::sequelPlatform_ = "sequelPlatform";
+const char* Settings::Option::allowUnsupportedChem_  = "allowUnsupportedChem";
 
 Settings::Settings(void)
     : mode(Settings::SubreadMode)
     , isInternal(false)
     , isSequelInput(false)
+    , isIgnoringChemistryCheck(false)
     , usingDeletionQV(true)
     , usingDeletionTag(true)
     , usingInsertionQV(true)
@@ -189,6 +191,10 @@ Settings Settings::FromCommandLine(optparse::OptionParser& parser,
     // internal file mode
     settings.isInternal = options.is_set(Settings::Option::internalMode_) ? options.get(Settings::Option::internalMode_)
                                                                           : false;
+
+    // strict/relaxed chemistry check
+    settings.isIgnoringChemistryCheck = options.is_set(Settings::Option::allowUnsupportedChem_) ? options.get(Settings::Option::allowUnsupportedChem_)
+                                                                                                : false;
 
     // platform
     settings.isSequelInput = options.is_set(Settings::Option::sequelPlatform_) ? options.get(Settings::Option::sequelPlatform_)

--- a/utils/bax2bam/src/Settings.h
+++ b/utils/bax2bam/src/Settings.h
@@ -30,6 +30,7 @@ public:
         static const char* internalMode_;
         static const char* outputXml_;
         static const char* sequelPlatform_;
+        static const char* allowUnsupportedChem_;
     };
 
 public:
@@ -55,6 +56,9 @@ public:
 
     // platform
     bool isSequelInput;
+
+    // chemistry checking?
+    bool isIgnoringChemistryCheck;
 
     // features
     bool usingDeletionQV;

--- a/utils/bax2bam/src/main.cpp
+++ b/utils/bax2bam/src/main.cpp
@@ -102,6 +102,16 @@ int main(int argc, char* argv[])
                       );
     parser.add_option_group(bamModeGroup);
 
+    auto additionalGroup = optparse::OptionGroup(parser, "Additional options");
+    additionalGroup.add_option("--allowUnrecognizedChemistryTriple")
+                   .dest(Settings::Option::allowUnsupportedChem_)
+                   .action("store_true")
+                   .help("By default, bax2bam only allows the conversion of files "
+                         "with chemistries that are supported in SMRT Analysis 3. "
+                         "Set this flag to disable the strict check and allow "
+                         "generation of BAM files containing legacy chemistries.");
+    parser.add_option_group(additionalGroup);
+
     // parse command line
     Settings settings = Settings::FromCommandLine(parser, argc, argv);
     if (!settings.errors.empty()) {


### PR DESCRIPTION
Allows the creation of BAM files from bax files containing legacy chemistries, while maintaining the strict check enabled by default.