### PR TITLE
Update bam2bax/bax2bam makefile for installation without pitchfork

### DIFF
--- a/utils/bam2bax/makefile
+++ b/utils/bam2bax/makefile
@@ -7,7 +7,8 @@ include ${SRCDIR}/../../rules.mk
 all: ${CURDIR}/src/*.cpp ${CURDIR}/src/*.h  ${CURDIR}/tests/src/*.cpp ${CURDIR}/tests/src/*.h
 	@mkdir -p ${CURDIR}/build && \
 	 cd ${CURDIR}/build && \
-		cmake -DPacBioBAM_INCLUDE_DIRS=${PBBAM_INC} \
+		cmake -DBOOST_ROOT=${BOOST_ROOT} \
+          -DPacBioBAM_INCLUDE_DIRS=${PBBAM_INC} \
           -DHTSLIB_INCLUDE_DIRS=${HTSLIB_INC} \
           -DPacBioBAM_LIBRARIES=${PBBAM_LIB}/libpbbam${SH_LIB_EXT} \
           -DHTSLIB_LIBRARIES=${HTSLIB_LIB}/libhts${SH_LIB_EXT} \

--- a/utils/bax2bam/makefile
+++ b/utils/bax2bam/makefile
@@ -1,13 +1,14 @@
 .PHONY=all
 
 SRCDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
--include ${CURDIR}/../../defines.mk
+include ${CURDIR}/../../defines.mk
 include ${SRCDIR}/../../rules.mk
 
 all: ${CURDIR}/src/* ${CURDIR}/tests/src/*
 	@mkdir -p ${CURDIR}/build && \
 	 cd ${CURDIR}/build && \
-		cmake -DPacBioBAM_INCLUDE_DIRS=${PBBAM_INC} \
+		cmake -DBOOST_ROOT=${BOOST_ROOT} \
+          -DPacBioBAM_INCLUDE_DIRS=${PBBAM_INC} \
           -DHTSLIB_INCLUDE_DIRS=${HTSLIB_INC} \
           -DPacBioBAM_LIBRARIES=${PBBAM_LIB}/libpbbam${SH_LIB_EXT} \
           -DHTSLIB_LIBRARIES=${HTSLIB_LIB}/libhts${SH_LIB_EXT} \


### PR DESCRIPTION
The fix should come with https://github.com/PacificBiosciences/blasr/wiki/INSTALL-bax2bam-without-using-pitchfork-(not-recommended)

This just covers (an edge case](https://github.com/PacificBiosciences/blasr/issues/245#issuecomment-226976670) when a user  want to install blasr and bax2bam without being able to use pitchfork. 

This should not affect any production build.
This should not affect pitchfork build.
