### PR TITLE
Do not use -isystem when the dir might be /usr/include

### DIFF
--- a/rules.mk
+++ b/rules.mk
@@ -33,5 +33,5 @@ LDLIBS+= \
 # We repeat LIBPBIHDF_LIBFLAGS because of a circular dependency. See #77.
 
 CPPFLAGS+=$(patsubst %,-I%,${INCDIRS})
-CPPFLAGS+=$(patsubst %,-isystem%,${SYSINCDIRS})
+CPPFLAGS+=$(patsubst %,-I%,${SYSINCDIRS})
 LDFLAGS+=$(patsubst %,-L%,${LIBDIRS})


### PR DESCRIPTION
* https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70129
* https://github.com/PacificBiosciences/blasr/issues/258
* https://github.com/PacificBiosciences/pitchfork/issues/265