### PR TITLE
Fix cram tests for --concordant

### DIFF
--- a/ctest/concordant.t
+++ b/ctest/concordant.t
@@ -2,29 +2,13 @@ Set up
   $ . $TESTDIR/setup.sh
 
 Test --concordant
-  $ rm -rf $OUTDIR/concordant_subset.bam
-  $ rm -rf $OUTDIR/concordant_subset.sam
-  $ $EXEC $DATDIR/ecoli_lp.fofn $DATDIR/ecoli_reference.fasta --concordant --refineConcordantAlignments --bam --out $OUTDIR/concordant_subset.bam --nproc 12 --holeNumbers 1--10000 --sa $DATDIR/ecoli_reference.sa
+  $ rm -rf $OUTDIR/concordant_subset.sam $OUTDIR/tmp1 $OUTDIR/tmp2
+  $ $EXEC $DATDIR/ecoli_lp.fofn $DATDIR/ecoli_reference.fasta --concordant --refineConcordantAlignments -m 4 --out $OUTDIR/concordant_subset.m4 --nproc 12 --holeNumbers 1--10000 --sa $DATDIR/ecoli_reference.sa
   [INFO]* (glob)
   [INFO]* (glob)
-  $ $SAMTOOLS view $OUTDIR/concordant_subset.bam > $OUTDIR/concordant_subset.sam
-  $ sed -n 6,110864p $OUTDIR/concordant_subset.sam > $OUTDIR/tmp1 
-  $ sort $OUTDIR/tmp1 > $OUTDIR/tmp11
-  $ sed -n 6,110864p $STDDIR/$UPDATEDATE/concordant_subset.sam > $OUTDIR/tmp2
-  $ sort $OUTDIR/tmp2 > $OUTDIR/tmp22
-  $ diff $OUTDIR/tmp11 $OUTDIR/tmp22
-  $ rm -rf $OUTDIR/tmp1 $OUTDIR/tmp2 $OUTDIR/tmp11 $OUTDIR/tmp22
-#2014_05_28  --> changelist 135254, use MAX_BAND_SIZE to contrain GuidedAlign
-#2014_08_21  --> changelist 138516, added YS, YE, ZM tags. 
-#2014_08_28  --> changelist 139176, update SAM MD5 
-#2014_09_12  --> changelist 140410, changed the default value of '--concordantTemplate' from 'longestsubread' to 'typicalsubread'
-#2014_09_17  --> changelist 140573, changed SDPFragment LessThan to make sure blasr compiled with gcc 4.4 and 4.8 can produce identical results. 
-#2014_10_16  --> changelist 141378, changed the default value of '--concordantTemplate' from 'typicalsubread' to 'mediansubread'
-#2015_03_01  --> changelist 146599, reads from the same movie should have unique readGroupId
-#2015_03_28  --> changelist 148101, 148080 updated read group id, 148100 updated TLEN
-#2015_04_09  --> changelist 148796, updated read group id
-#2015_04_25  --> changelist 149721, update CIGAR string, replace M with X=.
-#2015_04_25  --> changelist ?, force refine all concordant alignments
+  $ sort $OUTDIR/concordant_subset.m4 > $OUTDIR/tmp1
+Updated in 2016_10_05  --> changed output format from sam to m4, isolate concordant tests from file format tests
+  $ diff $OUTDIR/tmp1 $STDDIR/2016_10_05/concordant_subset.m4
 
 Test --concordant FMR1 case (the 'typical subread' is selected as template for concordant mapping)
   $ FOFN=$DATDIR/FMR1_concordant.fofn
@@ -33,3 +17,16 @@ Test --concordant FMR1 case (the 'typical subread' is selected as template for c
   [INFO]* (glob)
   [INFO]* (glob)
   $ diff $OUTDIR/FMR1_zmw_37927.m4 $STDDIR/$UPDATEDATE/FMR1_zmw_37927.m4
+  
+#History
+#2014_05_28  --> changelist 135254, use MAX_BAND_SIZE to contrain GuidedAlign
+#2014_08_21  --> changelist 138516, added YS, YE, ZM tags.
+#2014_08_28  --> changelist 139176, update SAM MD5
+#2014_09_12  --> changelist 140410, changed the default value of '--concordantTemplate' from 'longestsubread' to 'typicalsubread'
+#2014_09_17  --> changelist 140573, changed SDPFragment LessThan to make sure blasr compiled with gcc 4.4 and 4.8 can produce identical results.
+#2014_10_16  --> changelist 141378, changed the default value of '--concordantTemplate' from 'typicalsubread' to 'mediansubread'
+#2015_03_01  --> changelist 146599, reads from the same movie should have unique readGroupId
+#2015_03_28  --> changelist 148101, 148080 updated read group id, 148100 updated TLEN
+#2015_04_09  --> changelist 148796, updated read group id
+#2015_04_25  --> changelist 149721, update CIGAR string, replace M with X=.
+#2015_11_09  --> changelist 167117, added -refineConcordantAlignments


### PR DESCRIPTION
Changed test out file format from sam to m4 in
order to isolate testing of --concordant option
with testing of --sam file format.

TODO: add tests for --sam, may bring some [deprecated tests](https://github.com/PacificBiosciences/blasr/commit/f30a70a3ed8dc4ac5eeb5b6f12bf7cda5bac11ad) back as needed, see bug25741.t and bamIn.t for details.

TODO: deprecate --cigarUseSeqMatch which is no longer supported.

TODO: document changes in sam format
 + all pacbio QVs (e.g., dq, sq) now displays in sam file
 + Tags XS/XE/YS/YE/XL/XT/XQ have been removed
 + Tags qe/qs been added
 + Tag NM has been changed to nm
 + sam clipping (cigar)
   + Coordinate of sam clipping has been changed from within each subread to within unrolled zmw sequence.

TODO: document that the ```pbalign bax.h5 ref.fasta out.cmp.h5 --forQuiver``` (i.e., ```blasr --> samtoh5 --> loadPulses```) pipeline will no longer work for PacBio RS II data because of changes in sam format.