### PR TITLE
bax2bam: document that ccs mode requires ccs.h5 input

### DIFF
--- a/utils/bax2bam/src/main.cpp
+++ b/utils/bax2bam/src/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
     readModeGroup.add_option("--ccs")
                  .dest(Settings::Option::ccsMode_)
                  .action("store_true")
-                 .help("Output CCS sequences");
+                 .help("Output CCS sequences (requires ccs.h5 input)");
     parser.add_option_group(readModeGroup);
 
     auto featureGroup = optparse::OptionGroup(parser, "Pulse feature options");


### PR DESCRIPTION
(A customer had expression confusion as to whether bax2bam would call
CCS, which it doesn't)