### PR TITLE
Fix makefiles as needed to accomodate pbbam wrapping of htslib.

### DIFF
--- a/utils/bam2bax/BUILD.txt
+++ b/utils/bam2bax/BUILD.txt
@@ -9,6 +9,11 @@ Assuming that blasr and blaser_libcpp is placed under //depot/software/smrtanaly
 
 
 Build instructions for users:
+
+  If pbbam and htslib are prebuilt and included in blasr/defines.mk,
+  set PacBioBAM_INCLUDE_DIRS, HTSLIB_INCLUDE_DIRS, PacBioBAM_LIBRARIES
+  and HTSLIB_LIBRARIES as below. Otherwise, set PacBioBAM_RootDir instead.
+
   $ cd <bam2bax>
   $ mkdir build; cd build; 
   $ cmake -DPacBioBAM_INCLUDE_DIRS=<path_to_include_dir> \
@@ -26,23 +31,38 @@ Build instructions for users:
       -DHDF5_LIBRARIES=<path_to_lib_so_or_a> \
       -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
       ../
-
   $ make
   $ ../tests/bin/test_bam2bax # to test bam2bax exe
 
-# e.g.,
-#cmake -DPacBioBAM_INCLUDE_DIRS=$smrtanalysis/bioinformatics/lib/cpp/pbbam/include \
-#      -DHTSLIB_INCLUDE_DIRS=$smrtanalysis/bioinformatics/lib/cpp/htslib \
-#      -DPacBioBAM_LIBRARIES=$smrtanalysis/bioinformatics/lib/cpp/pbbam/lib/libpbbam.a \
-#      -DHTSLIB_LIBRARIES=$smrtanalysis/bioinformatics/lib/cpp/htslib/libhts.a \
-#      -DPBDATA_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata \
-#      -DPBDATA_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata/libpbdata.a \
-#      -DPBIHDF_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf \
-#      -DPBIHDF_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf/libpbihdf.a \
-#      -DBLASR_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/ \
-#      -DBLASR_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/libblasr.a \
-#      -DHDF5_INCLUDE_DIRS=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/include \
-#      -DHDF5_CPP_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5_cpp.a \
-#      -DHDF5_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5.a \
-#      -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
-#      ../
+
+  An example:
+  $ cmake -DPacBioBAM_INCLUDE_DIRS=$smrtanalysis/bioinformatics/lib/cpp/pbbam/include \
+      -DHTSLIB_INCLUDE_DIRS=$smrtanalysis/bioinformatics/lib/cpp/htslib \
+      -DPacBioBAM_LIBRARIES=$smrtanalysis/bioinformatics/lib/cpp/pbbam/lib/libpbbam.a \
+      -DHTSLIB_LIBRARIES=$smrtanalysis/bioinformatics/lib/cpp/htslib/libhts.a \
+      -DPBDATA_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata \
+      -DPBDATA_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata/libpbdata.a \
+      -DPBIHDF_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf \
+      -DPBIHDF_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf/libpbihdf.a \
+      -DBLASR_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/ \
+      -DBLASR_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/libblasr.a \
+      -DHDF5_INCLUDE_DIRS=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/include \
+      -DHDF5_CPP_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5_cpp.a \
+      -DHDF5_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5.a \
+      -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
+      ../
+
+  Alternatively:
+  $ cmake \ 
+      -DPacBioBAM_RootDir=$smrtanalsis/bioinformatics/lib/cpp/pbbam \
+      -DPBDATA_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata \
+      -DPBDATA_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/pbdata/libpbdata.a \
+      -DPBIHDF_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf \
+      -DPBIHDF_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/hdf/libpbihdf.a \
+      -DBLASR_INCLUDE_DIRS=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/ \
+      -DBLASR_LIBRARIES=$smrtanalysis/bioinformatics/ext/pi/blasr/libcpp/alignment/libblasr.a \
+      -DHDF5_INCLUDE_DIRS=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/include \
+      -DHDF5_CPP_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5_cpp.a \
+      -DHDF5_LIBRARIES=$smrtanalysis/prebuilt.out/hdf5/hdf5-1.8.12/ubuntu-1404/lib/libhdf5.a \
+      -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
+      ../

--- a/utils/bam2bax/CMakeLists.txt
+++ b/utils/bam2bax/CMakeLists.txt
@@ -66,8 +66,15 @@ endif()
 
 if (NOT PacBioBAM_INCLUDE_DIRS OR NOT PacBioBAM_LIBRARIES
     OR NOT HTSLIB_INCLUDE_DIRS OR NOT HTSLIB_LIBRARIES)
-    set(PacBioBAM_RootDir ${Bam2Bax_RootDir}/../../../../../lib/cpp/pbbam)
+    set(PacBioBAM_LIBRARIES )
+    set(PacBioBAM_INCLUDE_DIRS )
+    set(HTSLIB_INCLUDE_DIRS )
+    set(HTSLIB_LIBRARIES )
+    if (NOT PacBioBAM_RootDir)
+        message ("Must either set (PacBioBAM_INCLUDE_DIRS, PacBioBAM_LIBRARIES, HTSLIB_INCLUDE_DIRS, and HTSLIB_LIBRARIES) or PacBioBAM_RootDir!")
+    endif()
     add_subdirectory(${PacBioBAM_RootDir} external/build/pbbam)
+    set(PBBAM_LINK_FLAG pbbam)
 endif()
 
 if (NOT Boost_INCLUDE_DIRS)
@@ -130,4 +137,3 @@ if(Bam2Bax_build_tests)
     add_subdirectory(${GTEST_SRC_DIR} external/gtest/build)
     add_subdirectory(tests)
 endif()
-

--- a/utils/bam2bax/makefile
+++ b/utils/bam2bax/makefile
@@ -4,6 +4,9 @@ SRCDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 -include ${CURDIR}/../../defines.mk
 include ${SRCDIR}/../../rules.mk
 
+# If pbbam and htslib are prebuilt and included in defines.mk,
+# set PacBioBAM_INCLUDE_DIRS, HTSLIB_INCLUDE_DIRS, PacBioBAM_LIBRARIES
+# and HTSLIB_LIBRARIES as below. Otherwise, set PacBioBAM_RootDir instead.
 all: ${CURDIR}/src/*.cpp ${CURDIR}/src/*.h  ${CURDIR}/tests/src/*.cpp ${CURDIR}/tests/src/*.h
 	@mkdir -p ${CURDIR}/build && \
 	 cd ${CURDIR}/build && \
@@ -24,6 +27,25 @@ all: ${CURDIR}/src/*.cpp ${CURDIR}/src/*.h  ${CURDIR}/tests/src/*.cpp ${CURDIR}/
           -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
           ../ && \
 		make
+
+# If pbbam is not prebuilt, just set PacBioBAM_RootDir
+#all: ${CURDIR}/src/*.cpp ${CURDIR}/src/*.h  ${CURDIR}/tests/src/*.cpp ${CURDIR}/tests/src/*.h
+#	@mkdir -p ${CURDIR}/build && \
+#	 cd ${CURDIR}/build && \
+#		cmake -DBOOST_ROOT=${BOOST_ROOT} \
+#          -DPacBioBAM_RootDir=/home/UNIXHOME/yli/git/depot/software/smrtanalysis/bioinformatics/lib/cpp/pbbam \
+#          -DPBDATA_INCLUDE_DIRS=${LIBPBDATA_INC} \
+#          -DPBDATA_LIBRARIES=${LIBPBDATA_LIB}/libpbdata${SH_LIB_EXT} \
+#          -DPBIHDF_INCLUDE_DIRS=${LIBPBIHDF_INC} \
+#          -DPBIHDF_LIBRARIES=${LIBPBIHDF_LIB}/libpbihdf${SH_LIB_EXT} \
+#          -DBLASR_INCLUDE_DIRS=${LIBBLASR_INC}/ \
+#          -DBLASR_LIBRARIES=${LIBBLASR_LIB}/libblasr${SH_LIB_EXT} \
+#          -DHDF5_INCLUDE_DIRS=${HDF5_INC} \
+#          -DHDF5_CPP_LIBRARIES=${HDF5_LIB}/libhdf5_cpp${SH_LIB_EXT} \
+#          -DHDF5_LIBRARIES=${HDF5_LIB}/libhdf5${SH_LIB_EXT} \
+#          -DBam2Bax_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
+#          ../ && \
+#		make
 
 clean:
 	@rm -rf ${CURDIR}/bin/

--- a/utils/bam2bax/src/CMakeLists.txt
+++ b/utils/bam2bax/src/CMakeLists.txt
@@ -51,6 +51,7 @@ if (NOT APPLE)
 else()
 endif()
 target_link_libraries(bam2bax
+    ${PBBAM_LINK_FLAG}
     ${BLASR_LIBRARIES}
     ${PBIHDF_LIBRARIES}
     ${PBDATA_LIBRARIES}
@@ -67,6 +68,7 @@ set_target_properties(bam2plx PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY ${Bam2Bax_BinDir}
 )
 target_link_libraries(bam2plx
+    ${PBBAM_LINK_FLAG}
     ${BLASR_LIBRARIES}
     ${PBIHDF_LIBRARIES}
     ${PBDATA_LIBRARIES}

--- a/utils/bam2bax/tests/CMakeLists.txt
+++ b/utils/bam2bax/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ endif()
 target_link_libraries(test_bam2bax
     gtest
     gtest_main
+    ${PBBAM_LINK_FLAG}
     ${BLASR_LIBRARIES}
     ${PBIHDF_LIBRARIES}
     ${PBDATA_LIBRARIES}

--- a/utils/bax2bam/CMakeLists.txt
+++ b/utils/bax2bam/CMakeLists.txt
@@ -65,8 +65,15 @@ endif()
 
 if (NOT PacBioBAM_INCLUDE_DIRS OR NOT PacBioBAM_LIBRARIES
     OR NOT HTSLIB_INCLUDE_DIRS OR NOT HTSLIB_LIBRARIES)
-    set(PacBioBAM_RootDir  ${Bax2Bam_RootDir}/../../../../../lib/cpp/pbbam)
+    set(PacBioBAM_INCLUDE_DIRS )
+    set(PacBioBAM_LIBRARIES )
+    set(HTSLIB_INCLUDE_DIRS )
+    set(HTSLIB_LIBRARIES )
+    if (NOT PacBioBAM_RootDir)
+        message ("Must either set (PacBioBAM_INCLUDE_DIRS, PacBioBAM_LIBRARIES, HTSLIB_INCLUDE_DIRS, and HTSLIB_LIBRARIES) or PacBioBAM_RootDir!")
+    endif()
     add_subdirectory(${PacBioBAM_RootDir} external/build/pbbam)
+    set(PBBAM_LINK_FLAG pbbam)
 endif()
 
 if (NOT Boost_INCLUDE_DIRS)

--- a/utils/bax2bam/makefile
+++ b/utils/bax2bam/makefile
@@ -4,6 +4,9 @@ SRCDIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
 include ${CURDIR}/../../defines.mk
 include ${SRCDIR}/../../rules.mk
 
+# If pbbam and htslib are prebuilt and included in blasr/defines.mk,
+# set PacBioBAM_INCLUDE_DIRS, HTSLIB_INCLUDE_DIRS, PacBioBAM_LIBRARIES
+# and HTSLIB_LIBRARIES as below. Otherwise, just set PacBioBAM_RootDir instead.
 all: ${CURDIR}/src/* ${CURDIR}/tests/src/*
 	@mkdir -p ${CURDIR}/build && \
 	 cd ${CURDIR}/build && \
@@ -24,6 +27,7 @@ all: ${CURDIR}/src/* ${CURDIR}/tests/src/*
           -DBax2Bam_EXE_LINKER_FLAGS="-Wl,--no-as-needed -ldl -pthread -lrt " \
           ../ && \
 		make
+
 
 clean:
 	@rm -rf ${CURDIR}/bin/

--- a/utils/bax2bam/src/CMakeLists.txt
+++ b/utils/bax2bam/src/CMakeLists.txt
@@ -45,6 +45,7 @@ if (NOT APPLE)
 else()
 endif()
 target_link_libraries(bax2bam 
+    ${PBBAM_LINK_FLAG}
     ${BLASR_LIBRARIES}
     ${PBIHDF_LIBRARIES}
     ${PBDATA_LIBRARIES} 

--- a/utils/bax2bam/tests/CMakeLists.txt
+++ b/utils/bax2bam/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ endif()
 target_link_libraries(test_bax2bam
     gtest
     gtest_main
+    ${PBBAM_LINK_FLAG}
     ${BLASR_LIBRARIES}
     ${PBIHDF_LIBRARIES}
     ${PBDATA_LIBRARIES} 


### PR DESCRIPTION
Fix makefiles as needed to accomodate pbbam wrapping of htslib for bax2bam and bam2bax.

Support both the legacy way of specify prebuilt pbbam and htslibs include and lib, as well as building pbbam (which integrate htslib) as part of CMake from scratch.

Added instructions and examples.
Neither mobs nor pitchfork should be affected by this change.