### PR TITLE
Fix incorrect read group type in unrolled resequencing

### DIFF
--- a/ctest/noSplitSubreads.t
+++ b/ctest/noSplitSubreads.t
@@ -16,3 +16,37 @@ Test blasr with --noSplitSubreads
   [INFO]* (glob)
   $ sort $OUTDIR/lambda_bax_noSplitSubreads_tmp_subset.m4 > $OUTDIR/lambda_bax_noSplitSubreads_subset.m4
   $ diff $OUTDIR/lambda_bax_noSplitSubreads_subset.m4 $STDDIR/lambda_bax_noSplitSubreads_subset.m4
+
+# Test key command of unrolled resequencing, check bam header and alignments in output
+  $ outbam=$OUTDIR/unrolled-4mer.bam
+  $ outsam=$OUTDIR/unrolled-4mer.sam
+  $ query=$DATDIR/unrolled/m54006_151021_185942.subreadset.xml
+  $ ref=$DATDIR/unrolled/All4mer_V2_11_V2_13_V2_15_V2_44_circular_72x_l50256.fasta
+  $ stdsam=$STDDIR/unrolled-4mer.sam
+  $ rm -rf $outbam $outsam
+  $ $EXEC $query $ref --out $outbam --noSplitSubreads --fastMaxInterval --bam
+  [INFO]* (glob)
+  [INFO]* (glob)
+  $ $SAMTOOLS view -h $outbam -o $outsam
+  $ diff $outsam $stdsam
+  $ grep '@RG' $outsam
+  @RG\tID:e6043908* (glob)
+  $ grep 'RG:Z:e6043908' $outsam |wc -l
+  4
+
+
+  $ query=$DATDIR/unrolled/m54006_151021_185942.subreads.bam
+  $ outbam=$OUTDIR/unrolled-4mer-bam-in.bam
+  $ outsam=$OUTDIR/unrolled-4mer-bam-in.sam
+  $ rm -rf $outbam $outsam
+  $ $EXEC $query $ref --out $outbam --noSplitSubreads --fastMaxInterval --bam
+  [INFO]* (glob)
+  [INFO]* (glob)
+  $ $SAMTOOLS view -h $outbam -o $outsam
+  $ grep -v '^@PG' $outsam > ${outsam}.tmp && grep -v '^@PG' $stdsam > ${stdsam}.tmp && diff ${outsam}.tmp ${stdsam}.tmp
+  $ grep '@RG' $outsam
+  @RG\tID:e6043908* (glob)
+  $ grep 'RG:Z:e6043908' $outsam |wc -l
+  4
+
+

--- a/iblasr/MappingParameters.h
+++ b/iblasr/MappingParameters.h
@@ -714,6 +714,11 @@ public:
             return ReadType::CCS;
         }
         if (queryFileType == FileType::PBBAM) {
+            if (not mapSubreadsSeparately) {
+                // specifal case: blasr subread.bam ref.fa --noSplitSubreads
+                // input type seems like subread while infact is polymerase
+                return ReadType::POLYMERASE;
+            }
             // Read type in BAM may be CCS, SUBREAD, HQREGION or POLYMERASE.
             // Determine it later.
             return ReadType::UNKNOWN;
@@ -721,7 +726,11 @@ public:
         if (mapSubreadsSeparately) {
             return ReadType::SUBREAD;
         } else {
-            if (useHQRegionTable) {
+            if (useHQRegionTable and
+                (queryFileType == FileType::HDFCCSONLY or
+                 queryFileType == FileType::HDFBase or
+                 queryFileType == FileType::HDFPulse)) {
+                // Only HDF files can contain region table.
                 return ReadType::HQREGION;
             } else {
                 return ReadType::POLYMERASE;

--- a/iblasr/RegisterBlasrOptions.h
+++ b/iblasr/RegisterBlasrOptions.h
@@ -290,8 +290,8 @@ const string BlasrHelp(MappingParameters & params) {
              << "               Use no/hard/subread/soft clipping, ONLY for SAM/BAM output."<< endl
              << "   --printSAMQV (false)" << endl
              << "               Print quality values to SAM output." << endl
-             << "   --cigarUseSeqMatch (false)" << endl
-             << "               CIGAR strings in SAM/BAM output use '=' and 'X' to represent sequence match and mismatch instead of 'M'." << endl << endl
+//             << "   --cigarUseSeqMatch (false)" << endl
+//             << "               CIGAR strings in SAM/BAM output use '=' and 'X' to represent sequence match and mismatch instead of 'M'." << endl << endl
              << " Options for anchoring alignment regions. This will have the greatest effect on speed and sensitivity." << endl
              << "   --minMatch m (12) " << endl
              << "               Minimum seed length.  Higher minMatch will speed up alignment, " << endl


### PR DESCRIPTION
Fix incorrect read group type in unrolled resequencing.
Deprecate cigarUseSeqMatch option.