### PR TITLE
Fix CMake build dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ include_directories(
     ${BLASR_RootDir}/libcpp/pbdata
     ${HDF5_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}
+    ${LIBLZMA_INCLUDE_DIRS}
+    ${BZIP2_INCLUDE_DIRS}
+    ${CURL_INCLUDE_DIRS}
+    ${CRYPTO_INCLUDE_DIRS}
     ${PacBioBAM_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}/generated
 )
@@ -61,6 +65,10 @@ target_link_libraries(
     ${hts_LIBRARIES}
     ${ZLIB_LDFLAGS}
     ${HDF5_LDFLAGS}
+    ${LIBLZMA_LDFLAGS}
+    ${BZIP2_LDFLAGS}
+    ${CURL_LDFLAGS}
+    ${CRYPTO_LDFLAGS}
     )
 
 # Binaries

--- a/cmake/blasr-dependencies.cmake
+++ b/cmake/blasr-dependencies.cmake
@@ -19,6 +19,35 @@ else()
     set(ZLIB_LDFLAGS ${ZLIB_LIBRARIES})
 endif()
 
+# LZMA
+if (NOT LIBLZMA_LIBRARIES)
+    find_package(LibLZMA REQUIRED)
+else()
+    set(LIBLZMA_LDFLAGS ${LIBLZMA_LIBRARIES})
+endif()
+
+# BZIP2
+if (NOT BZIP2_LIBRARIES)
+    find_package(BZip2 REQUIRED)
+else()
+    set(BZIP2_LDFLAGS ${BZIP2_LIBRARIES})
+endif()
+
+# CURL
+if (NOT CURL_LIBRARIES)
+    find_package(CURL)
+else()
+    set(CURL_LDFLAGS ${CURL_LIBRARIES})
+endif()
+
+# LIBCRYPTO
+if (NOT CRYPTO_INCLUDE_DIRS OR NOT CRYPTO_LIBRARIES)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(CRYPTO libcrypto REQUIRED)
+else()
+    set(CRYPTO_LDFLAGS ${CRYPTO_LIBRARIES})
+endif()
+
 # HDF5
 if (HDF5_INCLUDE_DIR)
     message(FATAL_ERROR "Please specify HDF5_INCLUDE_DIRS not HDF5_INCLUDE_DIR!")


### PR DESCRIPTION
Add LZMA, BZIP2, CURL and LIBCRYPTO build dependencies. This should fix issue #383

Signed-off-by: Kai Blin <kblin@biosustain.dtu.dk>