### PR TITLE
Example params are wrong

### DIFF
--- a/doc/EXAMPLES.md
+++ b/doc/EXAMPLES.md
@@ -8,19 +8,19 @@
 
 Align reads from reads.bas.h5 to ecoli_K12 genome, and output in SAM format.
 
-    blasr reads.bas.h5  ecoli_K12.fasta -sam
+    blasr reads.bas.h5  ecoli_K12.fasta --sam --out alignments.sam
 
 Same as above, but with soft clipping
 
-    blasr reads.bas.h5  ecoli_K12.fasta -sam -clipping soft
+    blasr reads.bas.h5  ecoli_K12.fasta --sam --clipping soft --out alignments.sam
 
 Use multiple threads
 
-    blasr reads.bas.h5  ecoli_K12.fasta -sam -clipping soft -out alignments.sam -nproc 16
+    blasr reads.bas.h5  ecoli_K12.fasta --sam --clipping soft --out alignments.sam --nproc 16
 
 Include a larger minimal match, for faster but less sensitive alignments
 
-    blasr reads.bas.h5  ecoli_K12.fasta -sam -clipping soft -minMatch 15
+    blasr reads.bas.h5  ecoli_K12.fasta --sam --clipping soft --minMatch 15
 
 Produce alignments in a pairwise human readable format
 
@@ -29,10 +29,10 @@ Produce alignments in a pairwise human readable format
 Use a precomputed suffix array for faster startup
 
     sawriter hg19.fasta.sa hg19.fasta #First precompute the suffix array
-    blasr reads.bas.h5 hg19.fasta -sa hg19.fasta.sa
+    blasr reads.bas.h5 hg19.fasta --sa hg19.fasta.sa
 
 Use a precomputed BWT-FM index for smaller runtime memory footprint, but slower alignments.
 
     sa2bwt hg19.fasta hg19.fasta.sa hg19.fasta.bwt
-    blasr reads.bas.h5 hg19.fasta -bwt hg19.fasta.bwt
+    blasr reads.bas.h5 hg19.fasta --bwt hg19.fasta.bwt
 


### PR DESCRIPTION
"--out" is mandatory when "--sam" or "--bam" is specified. "--bwt" is also not shown in help message.